### PR TITLE
Change `conv` to 1e-20

### DIFF
--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -43,7 +43,7 @@ class DefectSystem(object):
     def defect_species_names(self):
         return [ ds.name for ds in self.defect_species ]
 
-    def get_sc_fermi(self, conv=1e-16, emin=None, emax=None, verbose=True):
+    def get_sc_fermi(self, conv=1e-20, emin=None, emax=None, verbose=True):
         """
         Solve to find value of E_fermi for which the DefectSystem is
         charge neutral
@@ -105,7 +105,7 @@ class DefectSystem(object):
             print(f'e_fermi: {e_fermi}')
         return e_fermi
 
-    def report(self, emin=None, emax=None, conv=1e-16):
+    def report(self, emin=None, emax=None, conv=1e-20):
         """
         print a report in the style of SC-FERMI which summarises key properties of
         the defect system.
@@ -218,7 +218,7 @@ class DefectSystem(object):
             transition_levels.update({ds:[x,y]})
         return transition_levels
 
-    def to_dict_per_volume(self, emin=None, emax=None, conv=1e-16, decomposed=False):
+    def to_dict_per_volume(self, emin=None, emax=None, conv=1e-20, decomposed=False):
         """
         returns a dictionary of relevent properties of the DefectSystem
         concentrations are reported in cm^-3
@@ -256,7 +256,7 @@ class DefectSystem(object):
         return {**run_stats, **concs}
 
 
-    def to_dict(self, emin=None, emax=None, conv=1e-16, decomposed=False):
+    def to_dict(self, emin=None, emax=None, conv=1e-20, decomposed=False):
         """
         returns a dictionary of relevent properties of the DefectSystem
         concentrations are reported per unit cell


### PR DESCRIPTION
Thanks for making such a useful package!

I noticed when calculating the SCF Fermi level for my system (CdTe), the `conv` parameter had to be decreased from the default 1e-16 to 1e-20, to converge the result. As this doesn't really add a noticeable increase to the calculation time, and is also a parameter that I guess most people would assume doesn't need to be touched, I think it should be decreased to be safe. 

I think a lot of the reason my system is likely to be relatively sensitive to this parameter, is the very low effective DOS at the CBM:
<img width="971" alt="image" src="https://user-images.githubusercontent.com/51478689/142725983-8888d3b2-bb21-4e4d-9462-2ae1584ce84f.png">
So I think this will primarily be relevant for people doing defects in high mobility semiconductors.

I've attached a notebook PDF example showing how the output Fermi level changes with the choice of this parameter.

[PR_PySCFermi_conv.pdf](https://github.com/bjmorgan/py-sc-fermi/files/7574514/PR_PySCFermi_conv.pdf)