### PR TITLE
Minor update to DOS handling (CBM indexing)

### DIFF
--- a/py_sc_fermi/dos.py
+++ b/py_sc_fermi/dos.py
@@ -223,7 +223,7 @@ class DOS:
         Returns:
             int: index of cbm
         """
-        return np.where(self._edos > self.bandgap)[0][0]
+        return np.where(self._edos >= self.bandgap)[0][0]
 
     def carrier_concentrations(
         self, e_fermi: float, temperature: float

--- a/tests/test_dos.py
+++ b/tests/test_dos.py
@@ -81,7 +81,7 @@ class TestDos(unittest.TestCase):
         self.assertEqual(self.dos._p0_index(), 50)
 
     def test__n0_index(self):
-        self.assertEqual(self.dos._n0_index(), 66)
+        self.assertEqual(self.dos._n0_index(), 65)
 
     def test_emin(self):
         self.assertEqual(self.dos.emin(), -10)


### PR DESCRIPTION
Just a minor update to CBM indexing in `pc-sc-fermi`, noticed from tests with [`doped`](https://doped.readthedocs.io).
MWE:
```python
from py_sc_fermi.dos import DOS
import numpy as np

dos = DOS(
    dos = np.array([1.0, 2.0, 0.0, 3.0, 4.0]),
    edos = np.array([-0.5, 0.0, 0.5, 1.0, 1.5]),
    bandgap=1.0,
    nelect=4,
)
dos._n0_index()  # index of CBM, used in carrier concentration functions
```

This should return `3` as the index, but gives `4` because of the use of `self._edos > self.bandgap` vs `self._edos >= self.bandgap`. Doesn't make much difference if a dense DOS is used so some inaccuracy in the exact VBM/CBM index doesn't matter, but does for less-dense DOSs, toy systems, dirac cones etc