### PR TITLE
Fix failing docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,3 @@ build:
   os: "ubuntu-22.04"
   tools:
     python: "3.12"
-
-sphinx:
-  configuration: docs/conf.py


### PR DESCRIPTION
Hi!
According to read-the-docs, the docs haven't successfully built in a year or so (though I don't think there's been much updates so not a big deal). 

https://app.readthedocs.org/projects/py-sc-fermi/builds/?utm_source=py-sc-fermi&utm_content=flyout

It seems to just be an issue with finding the `conf.py` file, which I think might be caused by this accidental near-duplicate text in the `readthedocs.yaml` config file.