### PR TITLE
Make DOS integrations more robust to noise / band edge effects

### DIFF
--- a/py_sc_fermi/dos.py
+++ b/py_sc_fermi/dos.py
@@ -49,10 +49,15 @@ class DOS:
                 f"maximum is taken as E=0. Got an energy range of [{self._edos[0]}, {self._edos[-1]}]."
             )
 
-        # Cache integration indices — depend only on edos and bandgap,
-        # before normalise_dos(), which reads _p0_int_idx via sum_dos().
+        # band-edge indices are determined as those closest to zero (for VBM) and bandgap (for CBM), rather
+        # than previous first-index-below-or-equal-to-zero and first-index-above-or-equal-to-bandgap, to
+        # avoid issues with accumulated noise in `edos` (e.g. ``edos`` of [-0.9999, 0.0001, 1.0001] should
+        # give VBM (``_p0_idx``) of 0.0001 not -0.9999:
         self._p0_idx = int(np.argmin(np.abs(self._edos)))
         self._n0_idx = int(np.argmin(np.abs(self._edos - self._bandgap)))
+
+        # Cache integration indices — depend only on edos and bandgap,
+        # before normalise_dos(), which reads _p0_int_idx via sum_dos():
         mid_gap = (self._p0_idx + self._n0_idx) // 2
         self._p0_integration_idx = max(mid_gap, self._p0_idx + 1)
         self._n0_integration_idx = min(mid_gap, self._n0_idx - 1) + 1

--- a/py_sc_fermi/dos.py
+++ b/py_sc_fermi/dos.py
@@ -1,10 +1,10 @@
 import numpy as np
 from typing import Tuple, Optional
-from scipy.constants import physical_constants  # type: ignore
-from scipy.integrate import trapezoid # type: ignore
+from scipy.constants import physical_constants
+from scipy.integrate import trapezoid
 
-from pymatgen.io.vasp import Vasprun # type: ignore
-from pymatgen.electronic_structure.core import Spin  # type: ignore
+from pymatgen.io.vasp import Vasprun
+from pymatgen.electronic_structure.core import Spin
 
 from py_sc_fermi.warnings import suppresses_numpy_overflow
 
@@ -195,11 +195,9 @@ class DOS:
     def sum_dos(self) -> np.ndarray:
         """
         Returns:
-            np.ndarray: integrated density-of-states up to the valence band maximum
+            np.ndarray: integrated density-of-states up to mid-gap
         """
-        vbm_index = np.where(self._edos <= 0)[0][-1]
-        sum1 = trapezoid(self._dos[: vbm_index + 1], self._edos[: vbm_index + 1])
-        return sum1
+        return trapezoid(self._dos[: self._p0_integration_index()], self._edos[: self._p0_integration_index()])
 
     def normalise_dos(self) -> None:
         """normalises the density of states w.r.t. number of electrons in the
@@ -230,7 +228,7 @@ class DOS:
         Returns:
             int: index of vbm
         """
-        return np.where(self._edos <= 0)[0][-1]
+        return np.argmin(np.abs(self._edos))
 
     def _n0_index(self) -> int:
         """find index of the conduction band minimum (cbm) in ``self.edos``
@@ -238,7 +236,19 @@ class DOS:
         Returns:
             int: index of cbm
         """
-        return np.where(self._edos >= self.bandgap)[0][0]
+        return np.argmin(np.abs(self._edos - self.bandgap))
+
+    def _mid_gap_index(self) -> int:
+        """find index of the mid-gap position in ``self.edos``"""
+        return round(self._p0_index() + (self._n0_index() - self._p0_index()) / 2)
+
+    def _p0_integration_index(self) -> int:
+        """find index of the starting point for integration of hole densities"""
+        return max(self._mid_gap_index(), self._p0_index() + 1)
+
+    def _n0_integration_index(self) -> int:
+        """find index of the starting point for integration of electron densities"""
+        return min(self._mid_gap_index(), self._n0_index() - 1) + 1
 
     @suppresses_numpy_overflow
     def carrier_concentrations(
@@ -255,26 +265,20 @@ class DOS:
         Returns:
             Tuple[float, float]: concentration of holes, concentration of electrons
         """
-        p0 = trapezoid(
-            self._p_func(e_fermi, temperature), self._edos[: self._p0_index() + 1]
-        )
-        n0 = trapezoid(
-            self._n_func(e_fermi, temperature), self._edos[self._n0_index() :]
-        )
+        p0 = trapezoid(self._p_func(e_fermi, temperature), self._edos[: self._p0_integration_index()])
+        n0 = trapezoid(self._n_func(e_fermi, temperature), self._edos[self._n0_integration_index() :])
         return p0, n0
 
     def _p_func(self, e_fermi: float, temperature: float) -> np.ndarray:
         """Fermi Dirac distribution for holes."""
-        return self.dos[: self._p0_index() + 1] / (
+        return self.dos[: self._p0_integration_index()] / (
             1.0
-            + np.exp(
-                (e_fermi - self.edos[: self._p0_index() + 1]) / (kboltz * temperature)
-            )
+            + np.exp((e_fermi - self.edos[: self._p0_integration_index()]) / (kboltz * temperature))
         )
 
     def _n_func(self, e_fermi: float, temperature: float) -> np.ndarray:
         """Fermi Dirac distribution for electrons."""
-        return self.dos[self._n0_index() :] / (
+        return self.dos[self._n0_integration_index() :] / (
             1.0
-            + np.exp((self.edos[self._n0_index() :] - e_fermi) / (kboltz * temperature))
+            + np.exp((self.edos[self._n0_integration_index() :] - e_fermi) / (kboltz * temperature))
         )

--- a/py_sc_fermi/dos.py
+++ b/py_sc_fermi/dos.py
@@ -42,6 +42,13 @@ class DOS:
         else:
             self._dos = dos
 
+        # The band-edge indices are found relative to E=0 (the VBM), so edos must bracket zero:
+        if not (self._edos[0] <= 0 <= self._edos[-1]):
+            raise ValueError(
+                f"DOS edos must bracket zero (i.e. extend above and below zero), as the valence band "
+                f"maximum is taken as E=0. Got an energy range of [{self._edos[0]}, {self._edos[-1]}]."
+            )
+
         # Cache integration indices — depend only on edos and bandgap,
         # before normalise_dos(), which reads _p0_int_idx via sum_dos().
         self._p0_idx = int(np.argmin(np.abs(self._edos)))

--- a/py_sc_fermi/dos.py
+++ b/py_sc_fermi/dos.py
@@ -228,7 +228,7 @@ class DOS:
         Returns:
             int: index of vbm
         """
-        return np.argmin(np.abs(self._edos))
+        return int(np.argmin(np.abs(self._edos)))
 
     def _n0_index(self) -> int:
         """find index of the conduction band minimum (cbm) in ``self.edos``
@@ -236,7 +236,7 @@ class DOS:
         Returns:
             int: index of cbm
         """
-        return np.argmin(np.abs(self._edos - self.bandgap))
+        return int(np.argmin(np.abs(self._edos - self.bandgap)))
 
     def _mid_gap_index(self) -> int:
         """find index of the mid-gap position in ``self.edos``"""

--- a/py_sc_fermi/dos.py
+++ b/py_sc_fermi/dos.py
@@ -240,7 +240,7 @@ class DOS:
 
     def _mid_gap_index(self) -> int:
         """find index of the mid-gap position in ``self.edos``"""
-        return round(self._p0_index() + (self._n0_index() - self._p0_index()) / 2)
+        return (self._p0_index() + self._n0_index()) // 2
 
     def _p0_integration_index(self) -> int:
         """find index of the starting point for integration of hole densities"""

--- a/py_sc_fermi/dos.py
+++ b/py_sc_fermi/dos.py
@@ -1,10 +1,10 @@
 import numpy as np
 from typing import Tuple, Optional
-from scipy.constants import physical_constants
-from scipy.integrate import trapezoid
+from scipy.constants import physical_constants  # type: ignore[import-untyped]
+from scipy.integrate import trapezoid  # type: ignore[import-untyped]
 
-from pymatgen.io.vasp import Vasprun
-from pymatgen.electronic_structure.core import Spin
+from pymatgen.io.vasp import Vasprun  # type: ignore[import-untyped]
+from pymatgen.electronic_structure.core import Spin  # type: ignore[import-untyped]
 
 from py_sc_fermi.warnings import suppresses_numpy_overflow
 

--- a/py_sc_fermi/dos.py
+++ b/py_sc_fermi/dos.py
@@ -42,6 +42,14 @@ class DOS:
         else:
             self._dos = dos
 
+        # Cache integration indices — depend only on edos and bandgap,
+        # before normalise_dos(), which reads _p0_int_idx via sum_dos().
+        self._p0_idx = int(np.argmin(np.abs(self._edos)))
+        self._n0_idx = int(np.argmin(np.abs(self._edos - self._bandgap)))
+        mid_gap = (self._p0_idx + self._n0_idx) // 2
+        self._p0_integration_idx = max(mid_gap, self._p0_idx + 1)
+        self._n0_integration_idx = min(mid_gap, self._n0_idx - 1) + 1
+        
         self.normalise_dos()
 
         if self.bandgap > self.emax():
@@ -197,7 +205,7 @@ class DOS:
         Returns:
             np.ndarray: integrated density-of-states up to mid-gap
         """
-        return trapezoid(self._dos[: self._p0_integration_index()], self._edos[: self._p0_integration_index()])
+        return trapezoid(self._dos[: self._p0_integration_idx], self._edos[: self._p0_integration_idx])
 
     def normalise_dos(self) -> None:
         """normalises the density of states w.r.t. number of electrons in the
@@ -222,34 +230,6 @@ class DOS:
         """
         return self._edos[-1]
 
-    def _p0_index(self) -> int:
-        """find index of the valence band maximum (vbm) in ``self.edos``
-
-        Returns:
-            int: index of vbm
-        """
-        return int(np.argmin(np.abs(self._edos)))
-
-    def _n0_index(self) -> int:
-        """find index of the conduction band minimum (cbm) in ``self.edos``
-
-        Returns:
-            int: index of cbm
-        """
-        return int(np.argmin(np.abs(self._edos - self.bandgap)))
-
-    def _mid_gap_index(self) -> int:
-        """find index of the mid-gap position in ``self.edos``"""
-        return (self._p0_index() + self._n0_index()) // 2
-
-    def _p0_integration_index(self) -> int:
-        """find index of the starting point for integration of hole densities"""
-        return max(self._mid_gap_index(), self._p0_index() + 1)
-
-    def _n0_integration_index(self) -> int:
-        """find index of the starting point for integration of electron densities"""
-        return min(self._mid_gap_index(), self._n0_index() - 1) + 1
-
     @suppresses_numpy_overflow
     def carrier_concentrations(
         self, e_fermi: float, temperature: float
@@ -265,20 +245,20 @@ class DOS:
         Returns:
             Tuple[float, float]: concentration of holes, concentration of electrons
         """
-        p0 = trapezoid(self._p_func(e_fermi, temperature), self._edos[: self._p0_integration_index()])
-        n0 = trapezoid(self._n_func(e_fermi, temperature), self._edos[self._n0_integration_index() :])
+        p0 = trapezoid(self._p_func(e_fermi, temperature), self._edos[: self._p0_integration_idx])
+        n0 = trapezoid(self._n_func(e_fermi, temperature), self._edos[self._n0_integration_idx :])
         return p0, n0
 
     def _p_func(self, e_fermi: float, temperature: float) -> np.ndarray:
         """Fermi Dirac distribution for holes."""
-        return self.dos[: self._p0_integration_index()] / (
+        return self.dos[: self._p0_integration_idx] / (
             1.0
-            + np.exp((e_fermi - self.edos[: self._p0_integration_index()]) / (kboltz * temperature))
+            + np.exp((e_fermi - self.edos[: self._p0_integration_idx]) / (kboltz * temperature))
         )
 
     def _n_func(self, e_fermi: float, temperature: float) -> np.ndarray:
         """Fermi Dirac distribution for electrons."""
-        return self.dos[self._n0_integration_index() :] / (
+        return self.dos[self._n0_integration_idx :] / (
             1.0
-            + np.exp((self.edos[self._n0_integration_index() :] - e_fermi) / (kboltz * temperature))
+            + np.exp((self.edos[self._n0_integration_idx :] - e_fermi) / (kboltz * temperature))
         )

--- a/py_sc_fermi/dos.py
+++ b/py_sc_fermi/dos.py
@@ -42,11 +42,16 @@ class DOS:
         else:
             self._dos = dos
 
-        # The band-edge indices are found relative to E=0 (the VBM), so edos must bracket zero:
         if not (self._edos[0] <= 0 <= self._edos[-1]):
             raise ValueError(
-                f"DOS edos must bracket zero (i.e. extend above and below zero), as the valence band "
-                f"maximum is taken as E=0. Got an energy range of [{self._edos[0]}, {self._edos[-1]}]."
+                f"DOS energy range must bracket zero (i.e. extend both above and below zero), "
+                f"as the valence band maximum is taken as E=0. "
+                f"Got [{self._edos[0]}, {self._edos[-1]}]."
+            )
+        if self._bandgap > self.emax():
+            raise ValueError(
+                f"bandgap ({self._bandgap}) > max(edos) ({self.emax()}); "
+                f"check your bandgap and energy range."
             )
 
         # band-edge indices are determined as those closest to zero (for VBM) and bandgap (for CBM), rather
@@ -56,19 +61,14 @@ class DOS:
         self._p0_idx = int(np.argmin(np.abs(self._edos)))
         self._n0_idx = int(np.argmin(np.abs(self._edos - self._bandgap)))
 
-        # Cache integration indices — depend only on edos and bandgap,
-        # before normalise_dos(), which reads _p0_int_idx via sum_dos():
+        # Cache integration indices — these depend only on edos and bandgap,
+        # neither of which can change after construction. Must be set before
+        # normalise_dos(), which reads _p0_integration_idx via sum_dos().
         mid_gap = (self._p0_idx + self._n0_idx) // 2
         self._p0_integration_idx = max(mid_gap, self._p0_idx + 1)
         self._n0_integration_idx = min(mid_gap, self._n0_idx - 1) + 1
-        
-        self.normalise_dos()
 
-        if self.bandgap > self.emax():
-            raise ValueError(
-                """bandgap > max(self.edos). Please check your bandgap and
-                 energy range (self.edos)."""
-            )
+        self.normalise_dos()
 
     @property
     def dos(self) -> np.ndarray:
@@ -215,7 +215,9 @@ class DOS:
     def sum_dos(self) -> np.ndarray:
         """
         Returns:
-            np.ndarray: integrated density-of-states up to mid-gap
+            np.ndarray: integrated density-of-states up to mid-gap, or up to
+                the grid point closest to the VBM if that sits above mid-gap
+                (narrow-gap case).
         """
         return trapezoid(self._dos[: self._p0_integration_idx], self._edos[: self._p0_integration_idx])
 

--- a/tests/test_dos.py
+++ b/tests/test_dos.py
@@ -78,10 +78,10 @@ class TestDos(unittest.TestCase):
         dos.sum_dos()
         np.testing.assert_allclose(dos.dos, dos_data)
 
-    def test__p0_index(self):
+    def test__p0_idx(self):
         self.assertEqual(self.dos._p0_idx, 49)
 
-    def test__n0_index(self):
+    def test__n0_idx(self):
         self.assertEqual(self.dos._n0_idx, 64)
 
     def test_emin(self):
@@ -149,7 +149,7 @@ class TestDos(unittest.TestCase):
         dos_data = np.ones_like(edos)
         with self.assertRaises(ValueError) as context:
             DOS(dos=dos_data, edos=edos, bandgap=3.0, nelect=10)
-        self.assertIn("DOS edos must bracket zero", str(context.exception))
+        self.assertIn("DOS energy range must bracket zero", str(context.exception))
 
     def test_from_vasprun(self):
         dos = self.dos.from_vasprun(test_vasprun_filename, nelect=320)

--- a/tests/test_dos.py
+++ b/tests/test_dos.py
@@ -171,7 +171,7 @@ class TestDos(unittest.TestCase):
             }
         )
         self.assertEqual(dos.nelect, 10)
-        self.assertEqual(dos.bandgap, 3.0)
+        self.assertEqual(dos.bandgap, bandgap)
         np.testing.assert_allclose(dos.dos, dos_data)
         self.assertEqual(dos.spin_polarised, True)
 

--- a/tests/test_dos.py
+++ b/tests/test_dos.py
@@ -31,9 +31,11 @@ class TestDOSInit(unittest.TestCase):
 
 class TestDos(unittest.TestCase):
     def setUp(self):
-        dos_data = np.ones(101)
-        edos = np.linspace(-10.0, 10.0, 101)
+        edos = np.linspace(-10.0, 10.0, 100)
         bandgap = 3.0
+        # Semiconducting DOS: density of 1 in the valence band (E <= 0) and
+        # conduction band (E >= bandgap), zero inside the gap:
+        dos_data = np.where((edos <= 0) | (edos >= bandgap), 1.0, 0.0)
         nelect = 10
         spin_polarised = False
         self.dos = DOS(
@@ -63,25 +65,24 @@ class TestDos(unittest.TestCase):
         self.assertFalse(self.dos.spin_polarised)
 
     def test_normalise_dos(self):
-        # The integral of rho(E) = 1, from -10.0 to 0, is equal to 10.0
-        # With nelect = 10.0, the normaliss_dos() method should leave
-        # all dos values = 1.0
-        dos_data = np.ones(101)
-        np.testing.assert_equal(self.dos.dos, dos_data)
+        expected = np.where(
+            (self.dos.edos <= 0) | (self.dos.edos >= self.dos.bandgap), 1.0, 0.0
+        )
+        np.testing.assert_allclose(self.dos.dos, expected)
 
     def test_sum_dos(self):
-        dos_data = np.ones(101)
-        dos = DOS(
-            dos=dos_data, edos=np.linspace(-10.0, 10.0, 101), bandgap=1, nelect=10
-        )
+        edos = np.linspace(-10.0, 10.0, 100)
+        bandgap = 1.0
+        dos_data = np.where((edos <= 0) | (edos >= bandgap), 1.0, 0.0)
+        dos = DOS(dos=dos_data, edos=edos, bandgap=bandgap, nelect=10)
         dos.sum_dos()
-        np.testing.assert_equal(dos.dos, dos_data)
+        np.testing.assert_allclose(dos.dos, dos_data)
 
     def test__p0_index(self):
-        self.assertEqual(self.dos._p0_index(), 50)
+        self.assertEqual(self.dos._p0_index(), 49)
 
     def test__n0_index(self):
-        self.assertEqual(self.dos._n0_index(), 65)
+        self.assertEqual(self.dos._n0_index(), 64)
 
     def test_emin(self):
         self.assertEqual(self.dos.emin(), -10)
@@ -139,35 +140,39 @@ class TestDos(unittest.TestCase):
         )
 
     def test_from_dict(self):
+        edos = np.linspace(-10.0, 10.0, 100)
+        bandgap = 3.0
+        dos_data = np.where((edos <= 0) | (edos >= bandgap), 1.0, 0.0)
         dos = self.dos.from_dict(
             {
-                "dos": np.ones(101),
-                "edos": np.linspace(-10.0, 10.0, 101),
-                "bandgap": 3.0,
+                "dos": dos_data,
+                "edos": edos,
+                "bandgap": bandgap,
                 "nelect": 10,
-                "spin_pol": False
+                "spin_pol": False,
             }
         )
         self.assertEqual(dos.nelect, 10)
-        self.assertEqual(dos.bandgap, 3.0)
-        np.testing.assert_equal(dos.dos, np.ones(101))
+        self.assertEqual(dos.bandgap, bandgap)
+        np.testing.assert_allclose(dos.dos, dos_data)
         self.assertEqual(dos.spin_polarised, False)
 
     def test_from_dict_with_spin_polarised(self):
+        edos = np.linspace(-10.0, 10.0, 100)
+        bandgap = 3.0
+        dos_data = np.where((edos <= 0) | (edos >= bandgap), 1.0, 0.0)
         dos = self.dos.from_dict(
             {
-                "dos": np.array([np.ones(101), np.ones(101)]),
-                "edos": np.linspace(-10.0, 10.0, 101),
-                "bandgap": 3.0,
+                "dos": np.array([dos_data / 2, dos_data / 2]),
+                "edos": edos,
+                "bandgap": bandgap,
                 "nelect": 10,
-                "spin_pol": True
+                "spin_pol": True,
             }
         )
         self.assertEqual(dos.nelect, 10)
         self.assertEqual(dos.bandgap, 3.0)
-        np.testing.assert_equal(
-            dos.dos, np.sum([np.ones(101) / 2, np.ones(101) / 2], axis=0)
-        )
+        np.testing.assert_allclose(dos.dos, dos_data)
         self.assertEqual(dos.spin_polarised, True)
 
     def test_as_dict(self):

--- a/tests/test_dos.py
+++ b/tests/test_dos.py
@@ -79,10 +79,10 @@ class TestDos(unittest.TestCase):
         np.testing.assert_allclose(dos.dos, dos_data)
 
     def test__p0_index(self):
-        self.assertEqual(self.dos._p0_index(), 49)
+        self.assertEqual(self.dos._p0_idx, 49)
 
     def test__n0_index(self):
-        self.assertEqual(self.dos._n0_index(), 64)
+        self.assertEqual(self.dos._n0_idx, 64)
 
     def test_emin(self):
         self.assertEqual(self.dos.emin(), -10)

--- a/tests/test_dos.py
+++ b/tests/test_dos.py
@@ -97,6 +97,60 @@ class TestDos(unittest.TestCase):
             1.7780649634855188e-30,
         )
 
+    def test_carrier_concentrations_robust_to_band_edge_index(self):
+        # carrier concentrations should be insensitive to the exact, noisy,
+        # auto-determined VBM/CBM indices. Here the physical DOS is held fixed
+        # (band edges at 0 and 3 eV) while the supplied bandgap is perturbed,
+        # which shifts the determined CBM index (_n0_idx) by two grid points,
+        # however the result should be unchanged:
+        edos = np.linspace(-10.0, 10.0, 100)
+        dos_data = np.where((edos <= 0) | (edos >= 3.0), 1.0, 0.0)
+        nelect = 10
+        e_fermi, T = 1.5, 298
+
+        result_exact = DOS(
+            dos=dos_data, edos=edos, bandgap=3.0, nelect=nelect
+        ).carrier_concentrations(e_fermi, T)
+        result_noisy = DOS(
+            dos=dos_data, edos=edos, bandgap=3.3, nelect=nelect
+        ).carrier_concentrations(e_fermi, T)
+
+        # sanity-check that the perturbed bandgap really does move the
+        # auto-determined band-edge index that the integration bound is built on
+        self.assertNotEqual(
+            DOS(dos=dos_data, edos=edos, bandgap=3.0, nelect=nelect)._n0_idx,
+            DOS(dos=dos_data, edos=edos, bandgap=3.3, nelect=nelect)._n0_idx,
+        )
+        np.testing.assert_allclose(result_exact, result_noisy, rtol=1e-3)
+
+    def test_integration_indices(self):
+        # default fixture (bandgap 3.0): p0_idx=49, n0_idx=64,
+        # mid_gap=(49+64)//2=56, so integration runs to mid-gap.
+        self.assertEqual(self.dos._p0_integration_idx, 56)
+        self.assertEqual(self.dos._n0_integration_idx, 57)
+
+    def test_integration_indices_narrow_bandgap_clamping(self):
+        # For a bandgap narrower than one grid spacing, mid-gap collapses onto
+        # the band-edge indices and the max(...)/min(...) clamps keep the hole
+        # and electron integration ranges valid and non-overlapping.
+        edos = np.linspace(-10.0, 10.0, 100)
+        bandgap = 0.1  # narrower than the ~0.2 eV grid spacing
+        dos_data = np.where((edos <= 0) | (edos >= bandgap), 1.0, 0.0)
+        dos = DOS(dos=dos_data, edos=edos, bandgap=bandgap, nelect=10)
+        self.assertEqual(dos._p0_idx, 49)
+        self.assertEqual(dos._n0_idx, 50)
+        # mid_gap=(49+50)//2 = 49 alone would make the hole range end before
+        # p0_idx, the clamps push both integration bounds to 50:
+        self.assertEqual(dos._p0_integration_idx, 50)  # (min, 50]
+        self.assertEqual(dos._n0_integration_idx, 50)  # [50, max)
+
+    def test_edos_must_bracket_zero(self):
+        edos = np.linspace(1.0, 10.0, 100)  # does not bracket E=0
+        dos_data = np.ones_like(edos)
+        with self.assertRaises(ValueError) as context:
+            DOS(dos=dos_data, edos=edos, bandgap=3.0, nelect=10)
+        self.assertIn("DOS edos must bracket zero", str(context.exception))
+
     def test_from_vasprun(self):
         dos = self.dos.from_vasprun(test_vasprun_filename, nelect=320)
         self.assertEqual(dos.nelect, 320)


### PR DESCRIPTION
This PR adjusts carrier concentration integrals to start from near the mid-gap position (intermediate between `idx_vbm` and `idx_cbm`), making the results now mostly independent of auto-determined VBM/CBM positions and indices (which can be sensitive to noise effects, and artificially affect trapezoidal integration by terminating integration early). 
Now it integrates the DOS with the Fermi-Dirac occupations, with the DOS being zero in the (true) gap until it reaches the (true) CBM/VBM, to give greater quantitative accuracy in the results.

This is essentially the same changes that were made to the ``pymatgen`` ``FermiDos`` integration scheme here:
https://github.com/materialsproject/pymatgen/pull/3879
https://github.com/materialsproject/pymatgen/pull/4240
– though in that case it still used a simple left Riemann / rectangular sum integration, now updated to use the more accurate trapezoidal integration as in `py-sc-fermi`:
https://github.com/materialsproject/pymatgen-core/pull/64

(And so now also has the desirable result of `doped`, `pymatgen` and `py-sc-fermi` doping calculations being fully self-consistent).