### PR TITLE
Store pool species references as names

### DIFF
--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -233,7 +233,8 @@ class DefectSystem:
         """Validate the species roster and pool references.
 
         Raises:
-            ValueError: if two roster species share a name.
+            ValueError: if two roster species share a name, or a pool
+                references a species not in the roster.
         """
         name_counts = Counter(ds.name for ds in self.defect_species)
         duplicates = sorted(name for name, count in name_counts.items() if count > 1)
@@ -241,6 +242,29 @@ class DefectSystem:
             raise ValueError(
                 f"defect_species contains duplicate names: {', '.join(duplicates)}. "
                 "Species names must be unique."
+            )
+
+        roster = set(name_counts)
+        for pool_name, (_, members) in self.site_pools.items():
+            self._check_pool_members("site pool", pool_name, members, roster)
+        for element, (_, pool_list) in self.element_pools.items():
+            member_names = [name for name, _ in pool_list]
+            self._check_pool_members("element pool", element, member_names, roster)
+
+    @staticmethod
+    def _check_pool_members(
+        kind: str, pool_name: str, members: list[str], roster: set[str]
+    ) -> None:
+        """Check one pool's species references against the roster names.
+
+        Raises:
+            ValueError: if a member name is not in `roster`.
+        """
+        unknown = sorted(set(members) - roster)
+        if unknown:
+            raise ValueError(
+                f"{kind} '{pool_name}' references species not in "
+                f"defect_species: {', '.join(unknown)}"
             )
 
     def __repr__(self) -> str:

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -258,13 +258,21 @@ class DefectSystem:
         """Check one pool's species references against the roster names.
 
         Raises:
-            ValueError: if a member name is not in `roster`.
+            ValueError: if a member name is not in `roster`, or a member
+                appears more than once.
         """
         unknown = sorted(set(members) - roster)
         if unknown:
             raise ValueError(
                 f"{kind} '{pool_name}' references species not in "
                 f"defect_species: {', '.join(unknown)}"
+            )
+        member_counts = Counter(members)
+        repeated = sorted(name for name, count in member_counts.items() if count > 1)
+        if repeated:
+            raise ValueError(
+                f"{kind} '{pool_name}' lists species more than once: "
+                f"{', '.join(repeated)}"
             )
 
     def __repr__(self) -> str:

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -4,7 +4,7 @@ import copy
 from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, TypeAlias
 
 import numpy as np
 from scipy.constants import physical_constants as _physical_constants
@@ -17,6 +17,19 @@ from py_sc_fermi.dos import DOS
 from py_sc_fermi.element_pools import ElementPoolError
 
 _kboltz = _physical_constants["Boltzmann constant in eV/K"][0]
+
+
+# Pools as accepted by the constructor: each species given as a DefectSpecies
+# object or by its name.
+SitePoolsInput: TypeAlias = dict[str, tuple[float, list[DefectSpecies | str]]]
+ElementPoolsInput: TypeAlias = dict[str, tuple[float, list[tuple[DefectSpecies | str, float]]]]
+
+# Pools as stored on a DefectSystem: references reduced to names.
+SitePools: TypeAlias = dict[str, tuple[float, list[str]]]
+ElementPools: TypeAlias = dict[str, tuple[float, list[tuple[str, float]]]]
+
+# Element pools with names resolved back to roster DefectSpecies (solve time).
+ElementPoolsResolved: TypeAlias = dict[str, tuple[float, list[tuple[DefectSpecies, float]]]]
 
 
 class _VariableState(NamedTuple):
@@ -51,9 +64,7 @@ def _species_name(species: DefectSpecies | str) -> str:
     return species.name if isinstance(species, DefectSpecies) else species
 
 
-def _normalise_site_pools(
-    site_pools: dict[str, tuple[float, list[DefectSpecies | str]]] | None,
-) -> dict[str, tuple[float, list[str]]]:
+def _normalise_site_pools(site_pools: SitePoolsInput | None) -> SitePools:
     """Reduce every site-pool species reference to a species name."""
     if not site_pools:
         return {}
@@ -63,9 +74,7 @@ def _normalise_site_pools(
     }
 
 
-def _normalise_element_pools(
-    element_pools: dict[str, tuple[float, list[tuple[DefectSpecies | str, float]]]] | None,
-) -> dict[str, tuple[float, list[tuple[str, float]]]]:
+def _normalise_element_pools(element_pools: ElementPoolsInput | None) -> ElementPools:
     """Reduce every element-pool species reference to a species name."""
     if not element_pools:
         return {}
@@ -90,7 +99,7 @@ class DefectSystem:
           will be solved for.
         convergence_tolerance (float, optional): Tolerance for the Fermi energy
           convergence in eV. If not specified, uses scipy's default.
-        site_pools (dict[str, tuple[float, list[DefectSpecies | str]]] | None, optional):
+        site_pools (SitePoolsInput | None, optional):
           Mapping of pool name -> (total sites in that pool, list of the
           DefectSpecies sharing those sites, each given as an object or by
           name). References are reduced to species names at construction,
@@ -100,7 +109,7 @@ class DefectSystem:
           compete with each other via Langmuir statistics; `site_pools` is
           only needed when several species must share one physical site
           budget.
-        element_pools (dict[str, tuple[float, list[tuple[DefectSpecies | str, float]]]] | None):
+        element_pools (ElementPoolsInput | None, optional):
           Mapping of element name -> (target content, list of
           (species, stoichiometry) pairs). Constrains the total amount of
           an element supplied by the listed species: the chemical
@@ -176,10 +185,8 @@ class DefectSystem:
         volume: float,
         temperature: float,
         convergence_tolerance: float | None = None,
-        site_pools: dict[str, tuple[float, list[DefectSpecies | str]]] | None = None,
-        element_pools: (
-            dict[str, tuple[float, list[tuple[DefectSpecies | str, float]]]] | None
-        ) = None,
+        site_pools: SitePoolsInput | None = None,
+        element_pools: ElementPoolsInput | None = None,
         vbm_shift: float = 0.0,
         cbm_shift: float = 0.0,
         formation_energy_corrections: dict[DefectChargeState, float] | None = None,
@@ -198,12 +205,8 @@ class DefectSystem:
             defect_species, formation_energy_corrections or {}
         )
 
-        self.site_pools: dict[str, tuple[float, list[str]]] = _normalise_site_pools(
-            site_pools
-        )
-        self.element_pools: dict[str, tuple[float, list[tuple[str, float]]]] = (
-            _normalise_element_pools(element_pools)
-        )
+        self.site_pools: SitePools = _normalise_site_pools(site_pools)
+        self.element_pools: ElementPools = _normalise_element_pools(element_pools)
 
         self._validate_pools()
 
@@ -477,9 +480,7 @@ class DefectSystem:
 
         return groups, fixed_concs
 
-    def _resolve_element_pools(
-        self,
-    ) -> dict[str, tuple[float, list[tuple[DefectSpecies, float]]]]:
+    def _resolve_element_pools(self) -> ElementPoolsResolved:
         """Resolve string species references in `element_pools` to DefectSpecies."""
         return {
             elem: (target, [(self._resolve_species(name), stoich) for name, stoich in pool_list])
@@ -488,7 +489,7 @@ class DefectSystem:
 
     @staticmethod
     def _stoichiometry_lookup(
-        pools: dict[str, tuple[float, list[tuple[DefectSpecies, float]]]],
+        pools: ElementPoolsResolved,
     ) -> dict[DefectSpecies, dict[str, float]]:
         """Map each species to {element: stoichiometry} for every element
         pool it participates in."""
@@ -500,7 +501,7 @@ class DefectSystem:
 
     @staticmethod
     def _remaining_element_targets(
-        pools: dict[str, tuple[float, list[tuple[DefectSpecies, float]]]],
+        pools: ElementPoolsResolved,
     ) -> dict[str, float]:
         """For each element pool, the target content still to be supplied by
         variable-concentration states, after subtracting fixed contributions."""
@@ -552,7 +553,7 @@ class DefectSystem:
         elements: list[str],
         stoich: dict[DefectSpecies, dict[str, float]],
         remaining: dict[str, float],
-        pools: dict[str, tuple[float, list[tuple[DefectSpecies, float]]]],
+        pools: ElementPoolsResolved,
     ) -> np.ndarray:
         """Solve for one chemical potential `mu_X` per element pool such
         that the total content of each pooled element, summed over every
@@ -574,7 +575,7 @@ class DefectSystem:
     def _solve_element_pools(
         self,
         groups: list[_ExclusionGroup],
-        pools: dict[str, tuple[float, list[tuple[DefectSpecies, float]]]],
+        pools: ElementPoolsResolved,
         elements: list[str],
         stoich: dict[DefectSpecies, dict[str, float]],
     ) -> tuple[np.ndarray, list[str], set[DefectSpecies]]:
@@ -943,9 +944,9 @@ class DefectSystemFactory:
         volume (float): volume of the unit cell in Angstroms cubed.
         convergence_tolerance (float, optional): Tolerance for the Fermi energy
           convergence in eV, passed to every `DefectSystem` built by `at()`.
-        site_pools (dict[str, tuple[float, list[DefectSpecies | str]]] | None, optional):
+        site_pools (SitePoolsInput | None, optional):
           passed to every `DefectSystem` built by `at()`.
-        element_pools (dict[str, tuple[float, list[tuple[DefectSpecies | str, float]]]] | None):
+        element_pools (ElementPoolsInput | None, optional):
           passed to every `DefectSystem` built by `at()`. Defaults to None.
         vbm_shift_fn (Callable[[float], float] | None, optional): a function
           of temperature returning the valence-band-maximum shift (in eV) at
@@ -967,10 +968,8 @@ class DefectSystemFactory:
         dos: DOS,
         volume: float,
         convergence_tolerance: float | None = None,
-        site_pools: dict[str, tuple[float, list[DefectSpecies | str]]] | None = None,
-        element_pools: (
-            dict[str, tuple[float, list[tuple[DefectSpecies | str, float]]]] | None
-        ) = None,
+        site_pools: SitePoolsInput | None = None,
+        element_pools: ElementPoolsInput | None = None,
         vbm_shift_fn: Callable[[float], float] | None = None,
         cbm_shift_fn: Callable[[float], float] | None = None,
         formation_energy_correction_fns: (

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -467,7 +467,7 @@ class DefectSystem:
         pooled_species: set[DefectSpecies] = set()
 
         for pool_name, (n_pool, species_list) in self.site_pools.items():
-            sp_objs = [self._resolve_species(sp) for sp in species_list]
+            sp_objs = [self._resolve_species(name) for name in species_list]
             pooled_species.update(sp_objs)
             groups.append(self._build_group(pool_name, n_pool, sp_objs, e_fermi, fixed_concs))
 
@@ -482,7 +482,7 @@ class DefectSystem:
     ) -> dict[str, tuple[float, list[tuple[DefectSpecies, float]]]]:
         """Resolve string species references in `element_pools` to DefectSpecies."""
         return {
-            elem: (target, [(self._resolve_species(sp), stoich) for sp, stoich in pool_list])
+            elem: (target, [(self._resolve_species(name), stoich) for name, stoich in pool_list])
             for elem, (target, pool_list) in self.element_pools.items()
         }
 

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -90,14 +90,18 @@ class DefectSystem:
           will be solved for.
         convergence_tolerance (float, optional): Tolerance for the Fermi energy
           convergence in eV. If not specified, uses scipy's default.
-        site_pools (dict[str, tuple[float, list[DefectSpecies]]] | None, optional):
-          Mapping of pool name -> (total sites in that pool, list of
-          DefectSpecies sharing those sites). By default (None), every
-          DefectSpecies gets its own implicit exclusion group of `nsites`
-          sites, so its charge states already compete with each other via
-          Langmuir statistics; `site_pools` is only needed when several
-          species must share one physical site budget.
-        element_pools (dict[str, tuple[float, list[tuple[Any, float]]]] | None, optional):
+        site_pools (dict[str, tuple[float, list[DefectSpecies | str]]] | None, optional):
+          Mapping of pool name -> (total sites in that pool, list of the
+          DefectSpecies sharing those sites, each given as an object or by
+          name). References are reduced to species names at construction,
+          so `site_pools` on the constructed system contains names only.
+          By default (None), every DefectSpecies gets its own implicit
+          exclusion group of `nsites` sites, so its charge states already
+          compete with each other via Langmuir statistics; `site_pools` is
+          only needed when several species must share one physical site
+          budget.
+        element_pools (dict[str, tuple[float, list[tuple[DefectSpecies | str, float]]]]
+          | None, optional):
           Mapping of element name -> (target content, list of
           (species, stoichiometry) pairs). Constrains the total amount of
           an element supplied by the listed species: the chemical
@@ -107,6 +111,7 @@ class DefectSystem:
           constraint, as distinct from a fixed thermodynamic chemical
           potential). Each species may be given as a `DefectSpecies`
           object or by name, and one species may appear in several pools.
+          References are reduced to species names at construction.
           The target is a content per unit cell on the same scale as the
           concentrations: fixed-concentration states count against it, and
           the remainder is distributed across the variable states. Mixed
@@ -146,6 +151,12 @@ class DefectSystem:
           defect levels are fixed in absolute energy while the band edges
           move, so such charge states have their formation energy shifted by
           `-charge * vbm_shift`.
+
+    Raises:
+        ValueError: if two entries in `defect_species` share a name, a pool
+          references a species not in `defect_species`, a pool lists a
+          species more than once, or a species appears in more than one
+          site pool.
 
     Note:
         `DefectSystem` is an immutable, fixed-temperature snapshot:
@@ -932,9 +943,10 @@ class DefectSystemFactory:
         volume (float): volume of the unit cell in Angstroms cubed.
         convergence_tolerance (float, optional): Tolerance for the Fermi energy
           convergence in eV, passed to every `DefectSystem` built by `at()`.
-        site_pools (dict[str, tuple[float, list[DefectSpecies]]] | None, optional):
+        site_pools (dict[str, tuple[float, list[DefectSpecies | str]]] | None, optional):
           passed to every `DefectSystem` built by `at()`.
-        element_pools (dict[str, tuple[float, list[tuple[Any, float]]]] | None, optional):
+        element_pools (dict[str, tuple[float, list[tuple[DefectSpecies | str, float]]]]
+          | None, optional):
           passed to every `DefectSystem` built by `at()`.
         vbm_shift_fn (Callable[[float], float] | None, optional): a function
           of temperature returning the valence-band-maximum shift (in eV) at

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -315,18 +315,15 @@ class DefectSystem:
                     )
         if self.site_pools:
             lines.append("\n  site pools:")
-            for pool_name, (n, species) in self.site_pools.items():
-                sp_names = ", ".join(
-                    sp.name if isinstance(sp, DefectSpecies) else sp
-                    for sp in species
+            for pool_name, (n, species_names) in self.site_pools.items():
+                lines.append(
+                    f"    {pool_name}: {n:.4g} sites  \u2192  [{', '.join(species_names)}]"
                 )
-                lines.append(f"    {pool_name}: {n:.4g} sites  \u2192  [{sp_names}]")
         if self.element_pools:
             lines.append("\n  element pools:")
             for elem, (n, pool_list) in self.element_pools.items():
                 sp_names = ", ".join(
-                    (sp if isinstance(sp, str) else sp.name) + f" \u00d7{stoich:g}"
-                    for sp, stoich in pool_list
+                    f"{name} \u00d7{stoich:g}" for name, stoich in pool_list
                 )
                 lines.append(f"    {elem}: {n:.4g} per cell  \u2192  [{sp_names}]")
         return "\n".join(lines)
@@ -396,9 +393,9 @@ class DefectSystem:
         print(output)
         return output
 
-    def _resolve_species(self, sp: DefectSpecies | str) -> DefectSpecies:
-        """Resolve a DefectSpecies or its name to a DefectSpecies instance."""
-        return self.defect_species_by_name(sp) if isinstance(sp, str) else sp
+    def _resolve_species(self, name: str) -> DefectSpecies:
+        """Resolve a species name to its entry in the roster."""
+        return self.defect_species_by_name(name)
 
     def _build_group(
         self,

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -155,8 +155,9 @@ class DefectSystem:
     Raises:
         ValueError: if two entries in `defect_species` share a name, a pool
           references a species not in `defect_species`, a pool lists a
-          species more than once, or a species appears in more than one
-          site pool.
+          species more than once, a species appears in more than one site
+          pool, or `formation_energy_corrections` references a
+          `DefectChargeState` that is not part of `defect_species`.
 
     Note:
         `DefectSystem` is an immutable, fixed-temperature snapshot:

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -233,8 +233,9 @@ class DefectSystem:
         """Validate the species roster and pool references.
 
         Raises:
-            ValueError: if two roster species share a name, or a pool
-                references a species not in the roster.
+            ValueError: if two roster species share a name, a pool references
+                a species not in the roster, a pool lists a species more than
+                once, or a species appears in more than one site pool.
         """
         name_counts = Counter(ds.name for ds in self.defect_species)
         duplicates = sorted(name for name, count in name_counts.items() if count > 1)
@@ -245,8 +246,17 @@ class DefectSystem:
             )
 
         roster = set(name_counts)
+        site_pool_of: dict[str, str] = {}
         for pool_name, (_, members) in self.site_pools.items():
             self._check_pool_members("site pool", pool_name, members, roster)
+            for name in members:
+                first = site_pool_of.setdefault(name, pool_name)
+                if first != pool_name:
+                    raise ValueError(
+                        f"species '{name}' appears in site pools '{first}' and "
+                        f"'{pool_name}'; a species may belong to at most one "
+                        "site pool"
+                    )
         for element, (_, pool_list) in self.element_pools.items():
             member_names = [name for name, _ in pool_list]
             self._check_pool_members("element pool", element, member_names, roster)

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -45,6 +45,35 @@ class _ExclusionGroup:
     variable_states: list[_VariableState]
 
 
+def _species_name(species: DefectSpecies | str) -> str:
+    """Reduce a species reference (a ``DefectSpecies`` or its name) to the name."""
+    return species.name if isinstance(species, DefectSpecies) else species
+
+
+def _normalise_site_pools(
+    site_pools: dict[str, tuple[float, list[DefectSpecies | str]]] | None,
+) -> dict[str, tuple[float, list[str]]]:
+    """Reduce every site-pool species reference to a species name."""
+    if not site_pools:
+        return {}
+    return {
+        pool_name: (n_sites, [_species_name(sp) for sp in species_list])
+        for pool_name, (n_sites, species_list) in site_pools.items()
+    }
+
+
+def _normalise_element_pools(
+    element_pools: dict[str, tuple[float, list[tuple[DefectSpecies | str, float]]]] | None,
+) -> dict[str, tuple[float, list[tuple[str, float]]]]:
+    """Reduce every element-pool species reference to a species name."""
+    if not element_pools:
+        return {}
+    return {
+        element: (target, [(_species_name(sp), stoich) for sp, stoich in pool_list])
+        for element, (target, pool_list) in element_pools.items()
+    }
+
+
 class DefectSystem:
     """This class is used to calculate the self consistent Fermi energy for
     a defective material, observing the condition of charge neutrality and
@@ -135,8 +164,10 @@ class DefectSystem:
         volume: float,
         temperature: float,
         convergence_tolerance: float | None = None,
-        site_pools: dict[str, tuple[float, list[DefectSpecies]]] | None = None,
-        element_pools: dict[str, tuple[float, list[tuple[Any, float]]]] | None = None,
+        site_pools: dict[str, tuple[float, list[DefectSpecies | str]]] | None = None,
+        element_pools: (
+            dict[str, tuple[float, list[tuple[DefectSpecies | str, float]]]] | None
+        ) = None,
         vbm_shift: float = 0.0,
         cbm_shift: float = 0.0,
         formation_energy_corrections: dict[DefectChargeState, float] | None = None,
@@ -150,17 +181,17 @@ class DefectSystem:
         self.cbm_shift = cbm_shift
         self.rigid_shift = rigid_shift
 
-        memo: dict[int, Any] = {}
-        self.defect_species = copy.deepcopy(defect_species, memo)
+        self.defect_species = copy.deepcopy(defect_species)
         self._apply_formation_energy_corrections(
             defect_species, formation_energy_corrections or {}
         )
 
-        # share `memo` so any DefectSpecies objects referenced by both
-        # `defect_species` and `site_pools`/`element_pools` resolve to the
-        # same copies as `self.defect_species`.
-        self.site_pools = copy.deepcopy(site_pools, memo) if site_pools else {}
-        self.element_pools = copy.deepcopy(element_pools, memo) if element_pools else {}
+        self.site_pools: dict[str, tuple[float, list[str]]] = _normalise_site_pools(
+            site_pools
+        )
+        self.element_pools: dict[str, tuple[float, list[tuple[str, float]]]] = (
+            _normalise_element_pools(element_pools)
+        )
 
     def _apply_formation_energy_corrections(
         self,
@@ -869,8 +900,10 @@ class DefectSystemFactory:
         dos: DOS,
         volume: float,
         convergence_tolerance: float | None = None,
-        site_pools: dict[str, tuple[float, list[DefectSpecies]]] | None = None,
-        element_pools: dict[str, tuple[float, list[tuple[Any, float]]]] | None = None,
+        site_pools: dict[str, tuple[float, list[DefectSpecies | str]]] | None = None,
+        element_pools: (
+            dict[str, tuple[float, list[tuple[DefectSpecies | str, float]]]] | None
+        ) = None,
         vbm_shift_fn: Callable[[float], float] | None = None,
         cbm_shift_fn: Callable[[float], float] | None = None,
         formation_energy_correction_fns: (

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -738,8 +738,15 @@ class DefectSystem:
 
         Returns:
             DefectSpecies: ``DefectSpecies`` where ``DefectSpecies.name == name``
+
+        Raises:
+            ValueError: if no ``DefectSpecies`` in the system has that name.
         """
-        return [ds for ds in self.defect_species if ds.name == name][0]
+        for ds in self.defect_species:
+            if ds.name == name:
+                return ds
+        available = ", ".join(self.defect_species_names)
+        raise ValueError(f"no defect species named '{name}'; available: {available}")
     
     def get_sc_fermi(self) -> tuple[float, float]:
         """Calculate the self-consistent Fermi energy.

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -100,8 +100,7 @@ class DefectSystem:
           compete with each other via Langmuir statistics; `site_pools` is
           only needed when several species must share one physical site
           budget.
-        element_pools (dict[str, tuple[float, list[tuple[DefectSpecies | str, float]]]]
-          | None, optional):
+        element_pools (dict[str, tuple[float, list[tuple[DefectSpecies | str, float]]]] | None):
           Mapping of element name -> (target content, list of
           (species, stoichiometry) pairs). Constrains the total amount of
           an element supplied by the listed species: the chemical
@@ -946,9 +945,8 @@ class DefectSystemFactory:
           convergence in eV, passed to every `DefectSystem` built by `at()`.
         site_pools (dict[str, tuple[float, list[DefectSpecies | str]]] | None, optional):
           passed to every `DefectSystem` built by `at()`.
-        element_pools (dict[str, tuple[float, list[tuple[DefectSpecies | str, float]]]]
-          | None, optional):
-          passed to every `DefectSystem` built by `at()`.
+        element_pools (dict[str, tuple[float, list[tuple[DefectSpecies | str, float]]]] | None):
+          passed to every `DefectSystem` built by `at()`. Defaults to None.
         vbm_shift_fn (Callable[[float], float] | None, optional): a function
           of temperature returning the valence-band-maximum shift (in eV) at
           that temperature. Defaults to None (no shift).

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, NamedTuple
@@ -193,6 +194,8 @@ class DefectSystem:
             _normalise_element_pools(element_pools)
         )
 
+        self._validate_pools()
+
     def _apply_formation_energy_corrections(
         self,
         original_defect_species: list[DefectSpecies],
@@ -225,6 +228,20 @@ class DefectSystem:
             else:
                 delta = 0.0
             copied_cs._energy += delta
+
+    def _validate_pools(self) -> None:
+        """Validate the species roster and pool references.
+
+        Raises:
+            ValueError: if two roster species share a name.
+        """
+        name_counts = Counter(ds.name for ds in self.defect_species)
+        duplicates = sorted(name for name, count in name_counts.items() if count > 1)
+        if duplicates:
+            raise ValueError(
+                f"defect_species contains duplicate names: {', '.join(duplicates)}. "
+                "Species names must be unique."
+            )
 
     def __repr__(self) -> str:
         bandgap = self.dos.bandgap + (self.cbm_shift - self.vbm_shift)

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -84,6 +84,12 @@ class TestDefectSystem(unittest.TestCase):
             self.defect_system.defect_species[0],
         )
 
+    def test_defect_species_by_name_raises_for_unknown_name(self):
+        with self.assertRaisesRegex(
+            ValueError, "no defect species named 'Xx'; available: v_O, O_i"
+        ):
+            self.defect_system.defect_species_by_name("Xx")
+
     def test_defect_species_names(self):
         self.assertEqual(self.defect_system.defect_species_names, ["v_O", "O_i"])
 

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -508,6 +508,18 @@ class TestDefectSystemPoolValidation(unittest.TestCase):
                 temperature=300,
             )
 
+    def test_site_pool_referencing_unknown_species_raises(self):
+        with self.assertRaisesRegex(
+            ValueError, "site pool 'shared' references species not in defect_species: C"
+        ):
+            self._system(site_pools={"shared": (10.0, ["A", "C"])})
+
+    def test_element_pool_referencing_unknown_species_raises(self):
+        with self.assertRaisesRegex(
+            ValueError, "element pool 'X' references species not in defect_species: C"
+        ):
+            self._system(element_pools={"X": (1.0, [("C", 1.0)])})
+
 
 class TestDefectSystemElementPools(unittest.TestCase):
     def setUp(self):

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -472,9 +472,12 @@ class TestDefectSystemSitePools(unittest.TestCase):
             volume=100,
             temperature=300,
             site_pools={"shared": (10.0, [self.species_a, "B"])},
+            element_pools={"dE": (1.0, [("A", 2.0)])},
         )
         self.assertIn("shared: 10 sites", repr(system))
         self.assertIn("[A, B]", repr(system))
+        self.assertIn("dE: 1 per cell", repr(system))
+        self.assertIn("A ×2", repr(system))
 
 
 class TestDefectSystemPoolValidation(unittest.TestCase):

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -520,6 +520,18 @@ class TestDefectSystemPoolValidation(unittest.TestCase):
         ):
             self._system(element_pools={"X": (1.0, [("C", 1.0)])})
 
+    def test_site_pool_listing_a_species_twice_raises(self):
+        with self.assertRaisesRegex(
+            ValueError, "site pool 'shared' lists species more than once: A"
+        ):
+            self._system(site_pools={"shared": (10.0, [self.species_a, "A"])})
+
+    def test_element_pool_listing_a_species_twice_raises(self):
+        with self.assertRaisesRegex(
+            ValueError, "element pool 'X' lists species more than once: A"
+        ):
+            self._system(element_pools={"X": (1.0, [("A", 1.0), ("A", -1.0)])})
+
 
 class TestDefectSystemElementPools(unittest.TestCase):
     def setUp(self):

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -465,6 +465,17 @@ class TestDefectSystemSitePools(unittest.TestCase):
         with self.assertRaises(ValueError):
             system._global_defect_concs(1.0)
 
+    def test_repr_lists_site_pools_by_name(self):
+        system = DefectSystem(
+            defect_species=[self.species_a, self.species_b],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+            site_pools={"shared": (10.0, [self.species_a, "B"])},
+        )
+        self.assertIn("shared: 10 sites", repr(system))
+        self.assertIn("[A, B]", repr(system))
+
 
 class TestDefectSystemPoolValidation(unittest.TestCase):
     def setUp(self):

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -466,6 +466,49 @@ class TestDefectSystemSitePools(unittest.TestCase):
             system._global_defect_concs(1.0)
 
 
+class TestDefectSystemPoolValidation(unittest.TestCase):
+    def setUp(self):
+        self.dos = DOS(
+            dos=np.ones(101),
+            edos=np.linspace(-5.0, 5.0, 101),
+            bandgap=2.0,
+            nelect=10,
+        )
+        self.species_a = DefectSpecies(
+            "A",
+            nsites=5,
+            charge_states=[DefectChargeState(charge=0, energy=1.0, degeneracy=1)],
+        )
+        self.species_b = DefectSpecies(
+            "B",
+            nsites=1,
+            charge_states=[DefectChargeState(charge=0, energy=0.8, degeneracy=1)],
+        )
+
+    def _system(self, **kwargs):
+        return DefectSystem(
+            defect_species=[self.species_a, self.species_b],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+            **kwargs,
+        )
+
+    def test_duplicate_roster_names_raise(self):
+        twin = DefectSpecies(
+            "A",
+            nsites=2,
+            charge_states=[DefectChargeState(charge=0, energy=1.5, degeneracy=1)],
+        )
+        with self.assertRaisesRegex(ValueError, "duplicate names: A"):
+            DefectSystem(
+                defect_species=[self.species_a, twin],
+                dos=self.dos,
+                volume=100,
+                temperature=300,
+            )
+
+
 class TestDefectSystemElementPools(unittest.TestCase):
     def setUp(self):
         self.dos = DOS(

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -403,6 +403,16 @@ class TestDefectSystemSitePools(unittest.TestCase):
         )
         self.assertLessEqual(total_occupied, n_pool)
 
+    def test_pool_references_are_normalised_to_names(self):
+        system = DefectSystem(
+            defect_species=[self.species_a, self.species_b],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+            site_pools={"shared": (10.0, [self.species_a, "B"])},
+        )
+        self.assertEqual(system.site_pools, {"shared": (10.0, ["A", "B"])})
+
     def test_pool_raises_when_fixed_concentrations_exceed_site_count(self):
         self.species_a.charge_states[0].fix_concentration(20.0)
         system = DefectSystem(
@@ -498,6 +508,16 @@ class TestDefectSystemElementPools(unittest.TestCase):
         concs = system._global_defect_concs(1.0)
         total_mg = sum(concs[cs] for cs in system.defect_species[0].charge_states)
         self.assertAlmostEqual(total_mg, target, places=6)
+
+    def test_element_pool_references_are_normalised_to_names(self):
+        system = DefectSystem(
+            defect_species=[self.species],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+            element_pools={"Mg": (0.5, [(self.species, 1.0)])},
+        )
+        self.assertEqual(system.element_pools, {"Mg": (0.5, [("Mg_Zn", 1.0)])})
 
     def test_element_pool_leaves_fixed_charge_states_unscaled(self):
         fixed_value = 2.0

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -595,14 +595,29 @@ class TestDefectSystemElementPools(unittest.TestCase):
         self.assertAlmostEqual(total_mg, target, places=6)
 
     def test_element_pool_references_are_normalised_to_names(self):
+        o_i = DefectSpecies(
+            "O_i",
+            nsites=4,
+            charge_states=[DefectChargeState(charge=0, energy=1.0, degeneracy=1)],
+        )
+        v_o = DefectSpecies(
+            "V_O",
+            nsites=4,
+            charge_states=[DefectChargeState(charge=0, energy=1.0, degeneracy=1)],
+        )
+        # Mixed object/name spelling, two members, asymmetric stoichiometries:
+        # pins that normalisation preserves both order and the name-stoichiometry
+        # pairing (a swap would invert the balance constraint).
         system = DefectSystem(
-            defect_species=[self.species],
+            defect_species=[o_i, v_o],
             dos=self.dos,
             volume=100,
             temperature=300,
-            element_pools={"Mg": (0.5, [(self.species, 1.0)])},
+            element_pools={"dO": (0.0, [(o_i, 2.0), ("V_O", -3.0)])},
         )
-        self.assertEqual(system.element_pools, {"Mg": (0.5, [("Mg_Zn", 1.0)])})
+        self.assertEqual(
+            system.element_pools, {"dO": (0.0, [("O_i", 2.0), ("V_O", -3.0)])}
+        )
 
     def test_element_pool_leaves_fixed_charge_states_unscaled(self):
         fixed_value = 2.0

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -386,23 +386,6 @@ class TestDefectSystemSitePools(unittest.TestCase):
         self.assertGreater(total_occupied, 0.0)
         self.assertLessEqual(total_occupied, n_pool)
 
-    def test_pools_can_reference_species_by_name(self):
-        n_pool = 10.0
-        system = DefectSystem(
-            defect_species=[self.species_a, self.species_b],
-            dos=self.dos,
-            volume=100,
-            temperature=300,
-            site_pools={"shared": (n_pool, ["A", "B"])},
-        )
-        concs = system._global_defect_concs(1.0)
-        total_occupied = sum(
-            concs[cs]
-            for sp in system.defect_species
-            for cs in sp.charge_states
-        )
-        self.assertLessEqual(total_occupied, n_pool)
-
     def test_pool_references_are_normalised_to_names(self):
         system = DefectSystem(
             defect_species=[self.species_a, self.species_b],

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -532,6 +532,21 @@ class TestDefectSystemPoolValidation(unittest.TestCase):
         ):
             self._system(element_pools={"X": (1.0, [("A", 1.0), ("A", -1.0)])})
 
+    def test_species_in_two_site_pools_raises(self):
+        with self.assertRaisesRegex(
+            ValueError, "species 'A' appears in site pools 'p1' and 'p2'"
+        ):
+            self._system(site_pools={"p1": (5.0, ["A"]), "p2": (5.0, ["A", "B"])})
+
+    def test_species_may_appear_in_multiple_element_pools(self):
+        system = self._system(
+            element_pools={
+                "X": (0.1, [("A", 1.0)]),
+                "Y": (0.1, [("A", 1.0), ("B", 1.0)]),
+            }
+        )
+        self.assertEqual(set(system.element_pools), {"X", "Y"})
+
 
 class TestDefectSystemElementPools(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## What this changes

`DefectSystem` now stores the species references in `site_pools` and
`element_pools` as species *names*, reduced at construction from whatever the
caller passed (a `DefectSpecies` object or a name string). Binding a name back
to a species happens at solve time, by lookup against the system's own roster
of defect species.

## Why

A `DefectSystem` deep-copies its `defect_species` at construction: it is a
fixed-temperature snapshot, and any energy corrections are baked into the
copies, so the caller's original objects must be left untouched. Pools,
however, could hold references to the caller's objects. To make those
references line up with the copied roster, the constructor threaded a shared
`deepcopy` memo through the roster and the pools.

That memo could preserve object identity across the copy, but it could not
*create* identity and could not *validate* intent. A pool reference was simply
trusted to be the very same object the caller also placed in `defect_species`
-- a contract that lived nowhere and failed silently when it was not met.

## Bugs this removes

Three silent wrong-physics modes, all rooted in identity-based pool
references:

- **Phantom species.** A pool referencing a `DefectSpecies` object that was
  not in `defect_species` was deep-copied into a private copy and quietly took
  part in the calculation, contributing concentrations no one declared.
- **Same-name double-counting.** A pool referencing a different object with
  the same name as a roster species was copied separately. The exclusion-group
  logic tests membership by object identity, so the species was counted twice:
  once in its pool, and once as its own implicit single-species group.
  Concretely, a two-site pool could report an occupancy of 7 instead of the
  correct 2.
- **Ambiguous roster names.** Two defect species sharing a name made the
  by-name lookup silently return the first match, so name-based references
  resolved arbitrarily.

## The fix

Reduce every pool reference to a name at construction and store names only. A
name is a symbolic reference that does not need to survive the copy graph: it
is resolved after copying, against the roster, which is the single source of
truth. Resolution can therefore only ever return a roster member, so phantoms
and twins are no longer representable rather than merely guarded against. The
shared-memo machinery is removed with them.

## Validation moved to construction

Each silent outcome above is now a loud `ValueError` raised at construction,
naming the offenders:

1. Defect-species names must be unique.
2. Every pool reference must resolve to a species in the roster.
3. No species may be listed twice within one pool (a repeat double-counts
   sites, and in an element pool silently overwrote its stoichiometry).
4. A species may belong to at most one site pool -- a site budget belongs to
   exactly one pool. Element pools may still overlap across pools, since one
   species can legitimately contribute to several element constraints.

## For callers

- The constructor still accepts `DefectSpecies` objects or name strings in
  pools; an object is simply read for its name. Existing calling code is
  unchanged.
- The `site_pools` and `element_pools` attributes now hold name strings rather
  than `DefectSpecies` objects, and the pool type hints on `DefectSystem` and
  `DefectSystemFactory` document the accepted union.
- There is no numerical change for any valid input.