### PR TITLE
Serialise pool constraints in DefectSystem.as_dict/from_dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@
   are satisfied simultaneously. Note: within a shared `site_pools` group, only
   each charge state's `degeneracy` (not its species' `nsites`) sets its
   relative weight.
+- `DefectSystem.as_dict`/`from_dict` now serialise `site_pools` and
+  `element_pools`, so a system with site or element constraints round-trips
+  through JSON and YAML (previously the pools were silently dropped). Each pool
+  is written as a self-describing mapping with species referenced by name.
+  `DOS.as_dict` now emits native Python floats, so a `DefectSystem` dictionary
+  is YAML-safe.
 - Added band-edge corrections (`vbm_shift`, `cbm_shift`,
   `formation_energy_corrections`, `rigid_shift`) to `DefectSystem`. `vbm_shift`
   and `cbm_shift` are pre-evaluated shifts (in eV) used to compute the

--- a/py_sc_fermi/defect_charge_state.py
+++ b/py_sc_fermi/defect_charge_state.py
@@ -118,11 +118,13 @@ class DefectChargeState:
 
         defect_dict = {
             "degeneracy": float(self.degeneracy),
-            "energy": self.energy,
+            "energy": float(self.energy) if self.energy is not None else None,
             "charge": int(self.charge),
         }
         if self.fixed_concentration is not None:
-            defect_dict.update({"fixed_concentration": self.fixed_concentration})
+            defect_dict.update(
+                {"fixed_concentration": float(self.fixed_concentration)}
+            )
 
         return defect_dict
 

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -4,7 +4,7 @@ import copy
 from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, NamedTuple, TypeAlias
+from typing import Any, NamedTuple, TypeAlias, TypedDict
 
 import numpy as np
 from scipy.constants import physical_constants as _physical_constants
@@ -30,6 +30,27 @@ ElementPools: TypeAlias = dict[str, tuple[float, list[tuple[str, float]]]]
 
 # Element pools with names resolved back to roster DefectSpecies (solve time).
 ElementPoolsResolved: TypeAlias = dict[str, tuple[float, list[tuple[DefectSpecies, float]]]]
+
+
+class SerialisedSitePool(TypedDict):
+    """JSON/YAML form of one site pool: a named site budget and its species."""
+
+    n_sites: float
+    species: list[str]
+
+
+class SerialisedElementMember(TypedDict):
+    """JSON/YAML form of one (species, stoichiometry) member of an element pool."""
+
+    species: str
+    stoichiometry: float
+
+
+class SerialisedElementPool(TypedDict):
+    """JSON/YAML form of one element pool: a target content and its members."""
+
+    target: float
+    members: list[SerialisedElementMember]
 
 
 class _VariableState(NamedTuple):
@@ -80,6 +101,30 @@ def _normalise_element_pools(element_pools: ElementPoolsInput | None) -> Element
         return {}
     return {
         element: (target, [(_species_name(sp), stoich) for sp, stoich in pool_list])
+        for element, (target, pool_list) in element_pools.items()
+    }
+
+
+def _site_pools_as_dict(site_pools: SitePools) -> dict[str, SerialisedSitePool]:
+    """Serialise stored site pools to JSON/YAML-safe mappings."""
+    return {
+        pool_name: {"n_sites": float(n_sites), "species": list(species_names)}
+        for pool_name, (n_sites, species_names) in site_pools.items()
+    }
+
+
+def _element_pools_as_dict(
+    element_pools: ElementPools,
+) -> dict[str, SerialisedElementPool]:
+    """Serialise stored element pools to JSON/YAML-safe mappings."""
+    return {
+        element: {
+            "target": float(target),
+            "members": [
+                {"species": name, "stoichiometry": float(stoich)}
+                for name, stoich in pool_list
+            ],
+        }
         for element, (target, pool_list) in element_pools.items()
     }
 
@@ -711,13 +756,28 @@ class DefectSystem:
     @classmethod
     def from_dict(cls, dictionary: dict) -> DefectSystem:
         """Generate a DefectSystem from a dictionary.
-    
+
+        Reads ``site_pools`` and ``element_pools`` when present; dictionaries
+        without those keys (e.g. older serialisations) load unchanged.
+
         Args:
-            dictionary (dict): Dictionary containing the DefectSystem data.
-    
+            dictionary (dict): Dictionary containing the DefectSystem data, as
+              produced by ``DefectSystem.as_dict``.
+
         Returns:
             DefectSystem: DefectSystem corresponding to the provided dictionary.
         """
+        site_pools = {
+            name: (pool["n_sites"], list(pool["species"]))
+            for name, pool in dictionary.get("site_pools", {}).items()
+        }
+        element_pools = {
+            element: (
+                pool["target"],
+                [(m["species"], m["stoichiometry"]) for m in pool["members"]],
+            )
+            for element, pool in dictionary.get("element_pools", {}).items()
+        }
         return cls(
             dos=DOS.from_dict(dictionary["dos"]),
             volume=dictionary["volume"],
@@ -727,6 +787,8 @@ class DefectSystem:
                 DefectSpecies.from_dict(defect_species)
                 for defect_species in dictionary["defect_species"]
             ],
+            site_pools=site_pools,
+            element_pools=element_pools,
         )
         
     def defect_species_by_name(self, name: str) -> DefectSpecies:
@@ -915,9 +977,21 @@ class DefectSystem:
     def as_dict(self) -> dict:
         """Return a dictionary representation of the ``DefectSystem``.
 
+        The returned dictionary contains only JSON/YAML-safe types and round-
+        trips through ``DefectSystem.from_dict``. ``site_pools`` and
+        ``element_pools`` are included only when non-empty; each pool is
+        serialised as a mapping with named fields, species referenced by name
+        (a site pool as ``{"n_sites", "species"}``; an element pool as
+        ``{"target", "members": [{"species", "stoichiometry"}]}``).
+
+        The serialised formation energies already include any corrections
+        applied at construction (``vbm_shift``, ``cbm_shift``,
+        ``formation_energy_corrections``, ``rigid_shift``); those constructor
+        parameters are deliberately not round-tripped, since re-applying a
+        non-rigid correction on load would double-count it.
+
         Returns:
-            dict: dictionary representation of the ``DefectSystem``, suitable for
-            round-tripping through ``DefectSystem.from_dict``.
+            dict: dictionary representation of the ``DefectSystem``.
         """
 
         defect_system_dict = dict(
@@ -930,6 +1004,12 @@ class DefectSystem:
         )
         if self.convergence_tolerance is not None:
             defect_system_dict["convergence_tolerance"] = self.convergence_tolerance
+        if self.site_pools:
+            defect_system_dict["site_pools"] = _site_pools_as_dict(self.site_pools)
+        if self.element_pools:
+            defect_system_dict["element_pools"] = _element_pools_as_dict(
+                self.element_pools
+            )
         return defect_system_dict
 
 

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -988,7 +988,7 @@ class DefectSystem:
         applied at construction (``vbm_shift``, ``cbm_shift``,
         ``formation_energy_corrections``, ``rigid_shift``); those constructor
         parameters are deliberately not round-tripped, since re-applying a
-        non-rigid correction on load would double-count it.
+        baked correction on load would double-count it.
 
         Returns:
             dict: dictionary representation of the ``DefectSystem``.
@@ -1003,7 +1003,7 @@ class DefectSystem:
             dos=self.dos.as_dict(),
         )
         if self.convergence_tolerance is not None:
-            defect_system_dict["convergence_tolerance"] = self.convergence_tolerance
+            defect_system_dict["convergence_tolerance"] = float(self.convergence_tolerance)
         if self.site_pools:
             defect_system_dict["site_pools"] = _site_pools_as_dict(self.site_pools)
         if self.element_pools:

--- a/py_sc_fermi/dos.py
+++ b/py_sc_fermi/dos.py
@@ -209,8 +209,8 @@ class DOS:
         return dict(
             nelect=int(self.nelect),
             bandgap=float(self.bandgap),
-            edos=list(self.edos),
-            dos=list(self.dos),
+            edos=self.edos.tolist(),
+            dos=self.dos.tolist(),
             spin_pol=False,
         )
 

--- a/tests/test_defect_charge_state.py
+++ b/tests/test_defect_charge_state.py
@@ -1,5 +1,8 @@
 import unittest
 
+import numpy as np
+import yaml
+
 from py_sc_fermi.defect_charge_state import DefectChargeState
 
 
@@ -176,6 +179,20 @@ class TestDefectChargeStateDictionaryOperations(unittest.TestCase):
         self.assertEqual(dictionary["energy"], 0.1234)
         self.assertEqual(dictionary["charge"], 1)
         self.assertEqual(dictionary["fixed_concentration"], 1)
+
+    def test_as_dict_emits_native_floats_for_numpy_values(self):
+        cs = DefectChargeState(charge=1, energy=np.float64(0.5), degeneracy=2)
+        cs.fix_concentration(np.float64(1e20))
+        dictionary = cs.as_dict()
+        self.assertIs(type(dictionary["energy"]), float)
+        self.assertIs(type(dictionary["fixed_concentration"]), float)
+        yaml.safe_dump(dictionary)
+
+    def test_as_dict_preserves_none_energy(self):
+        cs = DefectChargeState(charge=1, fixed_concentration=1e20)
+        dictionary = cs.as_dict()
+        self.assertIsNone(dictionary["energy"])
+        yaml.safe_dump(dictionary)
 
     def test_defect_charge_state_from_dict_warns(self):
         dictionary = {

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -5,6 +5,7 @@ from io import StringIO
 from unittest.mock import Mock, patch
 
 import numpy as np
+import yaml
 from scipy.constants import physical_constants
 
 from py_sc_fermi.defect_charge_state import DefectChargeState
@@ -1723,6 +1724,43 @@ class TestDefectSystemPoolSerialisation(unittest.TestCase):
         self.assertEqual(set(original), set(reloaded_totals))
         for name, total in original.items():
             self.assertAlmostEqual(reloaded_totals[name], total, places=8)
+
+    def test_round_trip_through_yaml_preserves_pools_and_physics(self):
+        system = self._system()
+        reloaded = DefectSystem.from_dict(
+            yaml.safe_load(yaml.safe_dump(system.as_dict()))
+        )
+        self.assertEqual(reloaded.site_pools, {"cation": (4.0, ["A", "B"])})
+        self.assertEqual(reloaded.element_pools, {"X": (0.3, [("C", 1.0)])})
+        original = self._concs_by_name(system, 1.0)
+        reloaded_totals = self._concs_by_name(reloaded, 1.0)
+        for name, total in original.items():
+            self.assertAlmostEqual(reloaded_totals[name], total, places=8)
+
+    def test_system_without_pools_emits_neither_key(self):
+        system = DefectSystem(
+            defect_species=[self.species_a],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+        )
+        as_dict = system.as_dict()
+        self.assertNotIn("site_pools", as_dict)
+        self.assertNotIn("element_pools", as_dict)
+
+    def test_dict_without_pool_keys_still_loads(self):
+        system = DefectSystem(
+            defect_species=[self.species_a],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+        )
+        as_dict = system.as_dict()
+        as_dict.pop("site_pools", None)
+        as_dict.pop("element_pools", None)
+        reloaded = DefectSystem.from_dict(as_dict)
+        self.assertEqual(reloaded.site_pools, {})
+        self.assertEqual(reloaded.element_pools, {})
 
 
 if __name__ == "__main__":

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -1,3 +1,4 @@
+import json
 import os
 import unittest
 from io import StringIO
@@ -1648,6 +1649,80 @@ class TestDefectSystemReport(unittest.TestCase):
         self.assertIn("1.93", output)
         self.assertNotIn("→", output)
         self.assertEqual(system.dos._bandgap, 2.0)
+
+
+class TestDefectSystemPoolSerialisation(unittest.TestCase):
+    def setUp(self):
+        self.dos = DOS(
+            dos=np.ones(101),
+            edos=np.linspace(-5.0, 5.0, 101),
+            bandgap=2.0,
+            nelect=10,
+        )
+        self.species_a = DefectSpecies(
+            "A",
+            nsites=5,
+            charge_states=[
+                DefectChargeState(charge=0, energy=1.0, degeneracy=1),
+                DefectChargeState(charge=1, energy=1.2, degeneracy=2),
+            ],
+        )
+        self.species_b = DefectSpecies(
+            "B",
+            nsites=1,
+            charge_states=[
+                DefectChargeState(charge=0, energy=0.8, degeneracy=1),
+                DefectChargeState(charge=-1, energy=1.5, degeneracy=2),
+            ],
+        )
+        self.species_c = DefectSpecies(
+            "C",
+            nsites=3,
+            charge_states=[
+                DefectChargeState(charge=0, energy=0.5, degeneracy=1),
+                DefectChargeState(charge=1, energy=0.9, degeneracy=2),
+            ],
+        )
+
+    def _system(self):
+        # site pool mixes object (A) and name ("B"); element pool references C
+        # by object -- exercises both reference spellings through normalisation.
+        return DefectSystem(
+            defect_species=[self.species_a, self.species_b, self.species_c],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+            site_pools={"cation": (4.0, [self.species_a, "B"])},
+            element_pools={"X": (0.3, [(self.species_c, 1.0)])},
+        )
+
+    @staticmethod
+    def _concs_by_name(system, e_fermi):
+        concs = system._global_defect_concs(e_fermi)
+        return {
+            ds.name: sum(concs.get(cs, 0.0) for cs in ds.charge_states)
+            for ds in system.defect_species
+        }
+
+    def test_round_trip_through_json_preserves_pools_and_physics(self):
+        system = self._system()
+        as_dict = system.as_dict()
+        self.assertEqual(
+            as_dict["site_pools"],
+            {"cation": {"n_sites": 4.0, "species": ["A", "B"]}},
+        )
+        self.assertEqual(
+            as_dict["element_pools"],
+            {"X": {"target": 0.3, "members": [{"species": "C", "stoichiometry": 1.0}]}},
+        )
+        reloaded = DefectSystem.from_dict(json.loads(json.dumps(as_dict)))
+        self.assertEqual(reloaded.site_pools, {"cation": (4.0, ["A", "B"])})
+        self.assertEqual(reloaded.element_pools, {"X": (0.3, [("C", 1.0)])})
+        original = self._concs_by_name(system, 1.0)
+        reloaded_totals = self._concs_by_name(reloaded, 1.0)
+        self.assertEqual(set(original), set(reloaded_totals))
+        for name, total in original.items():
+            self.assertAlmostEqual(reloaded_totals[name], total, places=8)
 
 
 if __name__ == "__main__":

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -1811,6 +1811,18 @@ class TestDefectSystemPoolSerialisation(unittest.TestCase):
             reloaded.element_pools, {"dX": (0.0, [("A", 1.0), ("C", -2.0)])}
         )
 
+    def test_numpy_convergence_tolerance_is_yaml_safe(self):
+        system = DefectSystem(
+            defect_species=[self.species_a],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+            convergence_tolerance=np.float64(1e-8),
+        )
+        as_dict = system.as_dict()
+        self.assertIs(type(as_dict["convergence_tolerance"]), float)
+        yaml.safe_dump(as_dict)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -1792,6 +1792,25 @@ class TestDefectSystemPoolSerialisation(unittest.TestCase):
         for name, total in original.items():
             self.assertAlmostEqual(reloaded_totals[name], total, places=8)
 
+    def test_multi_member_pools_round_trip_faithfully(self):
+        # A multi-member element pool with asymmetric, opposite-sign
+        # stoichiometries, and a species (A) that belongs to both a site pool
+        # and an element pool: pins that reconstruction preserves member order,
+        # the name-stoichiometry pairing, and the sign, with no cross-pool mix-up.
+        system = DefectSystem(
+            defect_species=[self.species_a, self.species_c],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+            site_pools={"shared": (6.0, [self.species_a, "C"])},
+            element_pools={"dX": (0.0, [(self.species_a, 1.0), ("C", -2.0)])},
+        )
+        reloaded = DefectSystem.from_dict(json.loads(json.dumps(system.as_dict())))
+        self.assertEqual(reloaded.site_pools, {"shared": (6.0, ["A", "C"])})
+        self.assertEqual(
+            reloaded.element_pools, {"dX": (0.0, [("A", 1.0), ("C", -2.0)])}
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -1762,6 +1762,36 @@ class TestDefectSystemPoolSerialisation(unittest.TestCase):
         self.assertEqual(reloaded.site_pools, {})
         self.assertEqual(reloaded.element_pools, {})
 
+    def test_corrections_round_trip_via_baked_energies(self):
+        donor_states = [
+            DefectChargeState(charge=0, energy=1.0, degeneracy=1),
+            DefectChargeState(charge=1, energy=0.6, degeneracy=2),
+        ]
+        acceptor_states = [
+            DefectChargeState(charge=0, energy=1.0, degeneracy=1),
+            DefectChargeState(charge=-1, energy=0.6, degeneracy=2),
+        ]
+        donor = DefectSpecies("D", nsites=2, charge_states=donor_states)
+        acceptor = DefectSpecies("Acc", nsites=2, charge_states=acceptor_states)
+        system = DefectSystem(
+            defect_species=[donor, acceptor],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+            vbm_shift=0.1,
+            cbm_shift=-0.05,
+            formation_energy_corrections={donor_states[1]: 0.2},
+            rigid_shift=False,
+        )
+        reloaded = DefectSystem.from_dict(json.loads(json.dumps(system.as_dict())))
+        e_original = system.get_sc_fermi()[0]
+        e_reloaded = reloaded.get_sc_fermi()[0]
+        self.assertAlmostEqual(e_original, e_reloaded, places=6)
+        original = self._concs_by_name(system, e_original)
+        reloaded_totals = self._concs_by_name(reloaded, e_reloaded)
+        for name, total in original.items():
+            self.assertAlmostEqual(reloaded_totals[name], total, places=8)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -1823,6 +1823,49 @@ class TestDefectSystemPoolSerialisation(unittest.TestCase):
         self.assertIs(type(as_dict["convergence_tolerance"]), float)
         yaml.safe_dump(as_dict)
 
+    def test_baked_numpy_correction_keeps_as_dict_yaml_safe(self):
+        # The documented temperature-dependent-shift workflow: a numpy vbm_shift
+        # with rigid_shift=False bakes -charge * vbm_shift into each energy,
+        # promoting it to np.float64. The whole-system dict must stay YAML-safe.
+        system = DefectSystem(
+            defect_species=[self.species_a, self.species_b],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+            vbm_shift=np.float64(0.1),
+            rigid_shift=False,
+        )
+        yaml.safe_dump(system.as_dict())
+
+    def test_fully_numpy_system_as_dict_is_yaml_safe(self):
+        # Contract guard at the boundary: every numeric field built from a numpy
+        # scalar. Catches a YAML-safety leak in any field without relying on a
+        # per-field test being remembered for it.
+        species = DefectSpecies(
+            "Z",
+            nsites=np.int64(4),
+            charge_states=[
+                DefectChargeState(
+                    charge=np.int64(0),
+                    energy=np.float64(0.5),
+                    degeneracy=np.float64(1),
+                ),
+                DefectChargeState(
+                    charge=np.int64(1), fixed_concentration=np.float64(1e19)
+                ),
+            ],
+        )
+        system = DefectSystem(
+            defect_species=[species],
+            dos=self.dos,
+            volume=np.float64(100.0),
+            temperature=np.float64(300.0),
+            convergence_tolerance=np.float64(1e-8),
+            site_pools={"p": (np.float64(4.0), ["Z"])},
+            element_pools={"X": (np.float64(0.5), [("Z", np.float64(1.0))])},
+        )
+        yaml.safe_dump(system.as_dict())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_dos.py
+++ b/tests/test_dos.py
@@ -3,6 +3,7 @@ import unittest
 from unittest.mock import Mock, patch
 
 import numpy as np
+import yaml
 
 from py_sc_fermi.dos import DOS
 
@@ -239,14 +240,20 @@ class TestDos(unittest.TestCase):
         self.assertEqual(dos.spin_polarised, True)
 
     def test_as_dict(self):
-        self.dos._dos = [1,2,3,4,5]
-        self.dos._edos = [1,2,3,4,5]
+        self.dos._dos = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        self.dos._edos = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
         dictionary = self.dos.as_dict()
-        self.assertEqual(dictionary["spin_pol"],False)
+        self.assertEqual(dictionary["spin_pol"], False)
         self.assertEqual(dictionary["nelect"], 10)
         self.assertEqual(dictionary["bandgap"], 3)
-        self.assertEqual(dictionary["edos"], [1,2,3,4,5])
-        self.assertEqual(dictionary["dos"], [1,2,3,4,5])
+        self.assertEqual(dictionary["edos"], [1.0, 2.0, 3.0, 4.0, 5.0])
+        self.assertEqual(dictionary["dos"], [1.0, 2.0, 3.0, 4.0, 5.0])
+
+    def test_as_dict_is_yaml_safe(self):
+        dictionary = self.dos.as_dict()
+        self.assertTrue(all(type(x) is float for x in dictionary["edos"]))
+        self.assertTrue(all(type(x) is float for x in dictionary["dos"]))
+        yaml.safe_dump(dictionary)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
DefectSystem.as_dict now emits site_pools and element_pools (when non-empty),
and from_dict reads them, so a system with site or element constraints
round-trips through JSON and YAML with identical physics. Previously these
pools were silently dropped, despite the as_dict docstring claiming the dict
was suitable for round-tripping.

Each pool is emitted as a self-describing mapping with species referenced by
name -- a site pool as {n_sites, species}, an element pool as {target, members
of {species, stoichiometry}} -- so a serialised file is legible and the dict
contains only JSON/YAML-safe types. from_dict reconstructs the constructor
arguments from these mappings, so a deserialised constrained system is
normalised and validated exactly as a hand-built one. Dictionaries without the
pool keys (older serialisations) load unchanged.

A prerequisite fix makes DOS.as_dict emit native Python floats instead of numpy
scalars, so the whole DefectSystem dictionary is YAML-safe; JSON already
tolerated the numpy scalars, which is why this was previously unnoticed.

The shift and correction constructor parameters (vbm_shift, cbm_shift,
formation_energy_corrections, rigid_shift) are deliberately not serialised:
their effect is baked into the charge-state energies at construction, which
defect_species already carries, so re-applying them on load would double-count
non-rigid corrections. A test pins that a corrected system round-trips to one
with matching solved concentrations.