### PR TITLE
Compute site_percentages from solved concentrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,19 @@
   `DefectSystem`, e.g. `{T: factory.at(T).concentration_dict() for T in
   temperatures}`.
 
+### Bug Fixes
+
+- `DefectSystem.site_percentages` is now computed from the solved,
+  site-exclusion- and pool-aware concentrations (`_global_defect_concs` at
+  the self-consistent Fermi level) rather than the unbounded dilute
+  Boltzmann expression. A near-saturation or pooled species previously
+  reported occupancies far above 100%, contradicting the concentrations from
+  `report` and `concentration_dict`; each species' occupancy is now divided
+  by the sites available to it (its own `nsites`, or the shared `site_pools`
+  size for a pooled species), so variable-concentration species are bounded
+  by 100%. An explicit `fixed_concentration` is reported faithfully and may
+  still exceed 100%.
+
 ## V2.2.2
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,9 +114,7 @@
   reported occupancies far above 100%, contradicting the concentrations from
   `report` and `concentration_dict`; each species' occupancy is now divided
   by the sites available to it (its own `nsites`, or the shared `site_pools`
-  size for a pooled species), so variable-concentration species are bounded
-  by 100%. An explicit `fixed_concentration` is reported faithfully and may
-  still exceed 100%.
+  size for a pooled species), so every reported occupancy is at most 100%.
 
 ## V2.2.2
 

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -1024,26 +1024,41 @@ class DefectSystem:
                 decomp_concs[str(ds.name)] = by_charge
             return {**run_stats, **decomp_concs}
 
-    def site_percentages(
-        self, 
-    ) -> dict[str, float]:
-        """Returns a dictionary of the DefectSpecies in the DefectSystem which
-        giving the percentage of the sites in the structure that will host that 
-        defect.
+    def site_percentages(self) -> dict[str, float]:
+        """Return each ``DefectSpecies``' solved site occupancy as a
+        percentage of the sites available to it.
+
+        The occupancies are taken from the same solved, pool- and
+        exclusion-aware concentrations as ``report`` and
+        ``concentration_dict`` (``_global_defect_concs`` at the
+        self-consistent Fermi level), so the three agree. For a
+        variable-concentration species the occupancy is at most 100%: site
+        exclusion caps a species' total at the sites available to it. The
+        denominator is that available site count -- the species' own
+        ``nsites``, or, for a species in a ``site_pools`` entry, the pool's
+        total site count, so a pool's members occupy at most 100% of it. An
+        explicit ``fixed_concentration`` exceeding the site count is reported
+        faithfully and may exceed 100%.
 
         Returns:
-            dict[str, Any]: dictionary specifying the per-DefectSpecies site
-            concentrations.
+            dict[str, float]: mapping of ``DefectSpecies`` name to its site
+            occupancy as a percentage.
         """
         e_fermi = self.get_sc_fermi()[0]
-
-        sum_concs = {
-                str(ds.name): float(
-                    (ds.get_concentration(e_fermi, self.temperature) / ds.nsites) * 100
-                )
-                for ds in self.defect_species
-            }
-        return sum_concs
+        concs = self._global_defect_concs(e_fermi)
+        pool_sites = {
+            name: n_sites
+            for n_sites, members in self.site_pools.values()
+            for name in members
+        }
+        return {
+            str(ds.name): float(
+                sum(concs.get(cs, 0.0) for cs in ds.charge_states)
+                / pool_sites.get(ds.name, ds.nsites)
+                * 100
+            )
+            for ds in self.defect_species
+        }
 
     def as_dict(self) -> dict:
         """Return a dictionary representation of the ``DefectSystem``.

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -1028,17 +1028,14 @@ class DefectSystem:
         """Return each ``DefectSpecies``' solved site occupancy as a
         percentage of the sites available to it.
 
-        The occupancies are taken from the same solved, pool- and
-        exclusion-aware concentrations as ``report`` and
-        ``concentration_dict`` (``_global_defect_concs`` at the
-        self-consistent Fermi level), so the three agree. For a
-        variable-concentration species the occupancy is at most 100%: site
-        exclusion caps a species' total at the sites available to it. The
-        denominator is that available site count -- the species' own
+        The occupancies are drawn from the same solved, pool- and
+        exclusion-aware concentrations as ``report`` and ``concentration_dict``
+        (``_global_defect_concs`` at the self-consistent Fermi level). The
+        denominator is the sites available to the species -- its own
         ``nsites``, or, for a species in a ``site_pools`` entry, the pool's
-        total site count, so a pool's members occupy at most 100% of it. An
-        explicit ``fixed_concentration`` exceeding the site count is reported
-        faithfully and may exceed 100%.
+        total site count (so a pool's members together occupy at most 100% of
+        it). A species' concentration cannot exceed its available sites, so
+        every occupancy is at most 100%.
 
         Returns:
             dict[str, float]: mapping of ``DefectSpecies`` name to its site

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -627,12 +627,17 @@ class TestDefectSystemSitePercentages(unittest.TestCase):
             volume=100,
             temperature=300,
         )
-        self.assertLessEqual(system.site_percentages()["R"], 100.0)
+        # Two-sided: a saturating species fills almost all its sites, so the
+        # occupancy is both bounded by 100% (the bug) and near it (not zero).
+        pct = system.site_percentages()["R"]
+        self.assertLessEqual(pct, 100.0)
+        self.assertGreater(pct, 99.0)
 
-    def test_site_percentages_match_global_defect_concs(self):
-        # One source of truth: the reported percentage equals the species'
-        # total in _global_defect_concs over its available sites, at the
-        # solved Fermi level.
+    def test_site_percentages_agree_with_concentration_dict(self):
+        # The documented contract: site_percentages reports the same solved
+        # concentrations as concentration_dict, just as an occupancy fraction.
+        # Comparing the two public methods pins that contract without
+        # duplicating the internal formula.
         species = DefectSpecies(
             "R",
             nsites=2,
@@ -647,10 +652,8 @@ class TestDefectSystemSitePercentages(unittest.TestCase):
             volume=100,
             temperature=300,
         )
-        e_fermi = system.get_sc_fermi()[0]
-        concs = system._global_defect_concs(e_fermi)
-        ds = system.defect_species[0]
-        expected = sum(concs[cs] for cs in ds.charge_states) / ds.nsites * 100
+        per_cell = system.concentration_dict(decomposed=False, per_volume=False)
+        expected = per_cell["R"] / species.nsites * 100
         self.assertAlmostEqual(system.site_percentages()["R"], expected, places=8)
 
     def test_pooled_species_percentages_bounded_by_pool(self):
@@ -698,6 +701,71 @@ class TestDefectSystemSitePercentages(unittest.TestCase):
         old_expression = species.get_concentration(e_fermi, 300) / species.nsites * 100
         new_pct = system.site_percentages()["D"]
         self.assertAlmostEqual(new_pct / old_expression, 1.0, places=6)
+
+    def test_fixed_concentration_within_sites_reports_faithful_ratio(self):
+        # A fixed concentration takes a distinct path (_build_group writes it
+        # straight into the concentrations); in budget it is reported
+        # faithfully as fixed / nsites, e.g. 3 of 4 sites -> 75%.
+        species = DefectSpecies(
+            "F",
+            nsites=4,
+            charge_states=[DefectChargeState(charge=0, energy=-0.5, degeneracy=1)],
+            fixed_concentration=3.0,
+        )
+        system = DefectSystem(
+            defect_species=[species],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+        )
+        self.assertAlmostEqual(system.site_percentages()["F"], 75.0, places=8)
+
+    def test_fixed_concentration_exceeding_sites_is_not_reported(self):
+        # A fixed concentration above the site budget cannot be hosted: the
+        # solve raises rather than returning an occupancy above 100%.
+        species = DefectSpecies(
+            "F",
+            nsites=2,
+            charge_states=[DefectChargeState(charge=0, energy=-0.5, degeneracy=1)],
+            fixed_concentration=5.0,
+        )
+        system = DefectSystem(
+            defect_species=[species],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+        )
+        with self.assertRaises(RuntimeError):
+            system.site_percentages()
+
+    def test_mixed_pooled_and_unpooled_species_use_their_own_denominators(self):
+        # A pooled species is divided by the pool size; an unpooled species in
+        # the same system is divided by its own nsites.
+        pooled = DefectSpecies(
+            "P",
+            nsites=5,
+            charge_states=[DefectChargeState(charge=0, energy=-0.5, degeneracy=1)],
+        )
+        unpooled = DefectSpecies(
+            "U",
+            nsites=3,
+            charge_states=[DefectChargeState(charge=0, energy=-0.5, degeneracy=1)],
+        )
+        system = DefectSystem(
+            defect_species=[pooled, unpooled],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+            site_pools={"shared": (4.0, [pooled])},
+        )
+        per_cell = system.concentration_dict(decomposed=False, per_volume=False)
+        pct = system.site_percentages()
+        # P's own nsites is 5, but as a pool member its denominator is the
+        # pool size 4.0; U falls back to its own nsites 3.
+        self.assertAlmostEqual(pct["P"], per_cell["P"] / 4.0 * 100, places=8)
+        self.assertAlmostEqual(pct["U"], per_cell["U"] / 3.0 * 100, places=8)
+        self.assertLessEqual(pct["P"], 100.0)
+        self.assertLessEqual(pct["U"], 100.0)
 
 
 class TestDefectSystemPoolValidation(unittest.TestCase):

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -148,19 +148,6 @@ class TestDefectSystem(unittest.TestCase):
         self.assertEqual(defect_system.temperature, 100)
         self.assertEqual(defect_system.convergence_tolerance, 1)
 
-    def test_site_percentages(self):
-        self.defect_system.get_sc_fermi = Mock(return_value=[1, {}])
-        self.defect_system.dos.carrier_concentrations = Mock(return_value=(1, 1))
-        self.defect_system.defect_species[0].get_concentration = Mock(return_value=1)
-        self.defect_system.defect_species[1].get_concentration = Mock(return_value=1)
-        self.defect_system.defect_species[0].nsites = 1
-        self.defect_system.defect_species[1].nsites = 1
-        self.defect_system.defect_species[0].name = "v_O"
-        self.defect_system.defect_species[1].name = "O_i"
-        self.assertEqual(
-            self.defect_system.site_percentages(), {"v_O": 100, "O_i": 100}
-        )
-
     def test_get_sc_fermi(self):
         self.defect_system.dos.emin = Mock(return_value=0)
         self.defect_system.dos.emax = Mock(return_value=1)
@@ -614,6 +601,103 @@ class TestDefectSystemSitePools(unittest.TestCase):
         self.assertIn("[A, B]", repr(system))
         self.assertIn("dE: 1 per cell", repr(system))
         self.assertIn("A ×2", repr(system))
+
+
+class TestDefectSystemSitePercentages(unittest.TestCase):
+    def setUp(self):
+        self.dos = DOS(
+            dos=np.ones(101),
+            edos=np.linspace(-5.0, 5.0, 101),
+            bandgap=2.0,
+            nelect=10,
+        )
+
+    def test_near_saturation_species_reports_at_most_100_percent(self):
+        # Reproduction: a low-energy single species saturates its sites.
+        # The unbounded dilute formula reported ~2.5e10%; the solved
+        # concentration caps it at nsites, i.e. <= 100%.
+        species = DefectSpecies(
+            "R",
+            nsites=2,
+            charge_states=[DefectChargeState(charge=0, energy=-0.5, degeneracy=1)],
+        )
+        system = DefectSystem(
+            defect_species=[species],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+        )
+        self.assertLessEqual(system.site_percentages()["R"], 100.0)
+
+    def test_site_percentages_match_global_defect_concs(self):
+        # One source of truth: the reported percentage equals the species'
+        # total in _global_defect_concs over its available sites, at the
+        # solved Fermi level.
+        species = DefectSpecies(
+            "R",
+            nsites=2,
+            charge_states=[
+                DefectChargeState(charge=0, energy=-0.5, degeneracy=1),
+                DefectChargeState(charge=1, energy=0.3, degeneracy=2),
+            ],
+        )
+        system = DefectSystem(
+            defect_species=[species],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+        )
+        e_fermi = system.get_sc_fermi()[0]
+        concs = system._global_defect_concs(e_fermi)
+        ds = system.defect_species[0]
+        expected = sum(concs[cs] for cs in ds.charge_states) / ds.nsites * 100
+        self.assertAlmostEqual(system.site_percentages()["R"], expected, places=8)
+
+    def test_pooled_species_percentages_bounded_by_pool(self):
+        # Two species sharing a site pool: each <= 100% and, since the pool
+        # size is the shared denominator, their percentages sum to <= 100%.
+        species_a = DefectSpecies(
+            "A",
+            nsites=5,
+            charge_states=[DefectChargeState(charge=0, energy=-0.5, degeneracy=1)],
+        )
+        species_b = DefectSpecies(
+            "B",
+            nsites=5,
+            charge_states=[DefectChargeState(charge=0, energy=-0.3, degeneracy=1)],
+        )
+        system = DefectSystem(
+            defect_species=[species_a, species_b],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+            site_pools={"shared": (4.0, [species_a, species_b])},
+        )
+        pct = system.site_percentages()
+        self.assertLessEqual(pct["A"], 100.0)
+        self.assertLessEqual(pct["B"], 100.0)
+        self.assertLessEqual(pct["A"] + pct["B"], 100.0)
+
+    def test_dilute_regime_matches_old_expression(self):
+        # A high formation energy is firmly in the dilute limit, where site
+        # exclusion (c = n_free * w / (1 + w)) and the old dilute expression
+        # (c = nsites * w) agree. Compared as a ratio because the absolute
+        # percentage is astronomically small at this energy.
+        species = DefectSpecies(
+            "D",
+            nsites=2,
+            charge_states=[DefectChargeState(charge=0, energy=1.5, degeneracy=1)],
+        )
+        system = DefectSystem(
+            defect_species=[species],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+        )
+        e_fermi = system.get_sc_fermi()[0]
+        old_expression = species.get_concentration(e_fermi, 300) / species.nsites * 100
+        new_pct = system.site_percentages()["D"]
+        self.assertAlmostEqual(new_pct / old_expression, 1.0, places=6)
 
 
 class TestDefectSystemPoolValidation(unittest.TestCase):

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -720,24 +720,6 @@ class TestDefectSystemSitePercentages(unittest.TestCase):
         )
         self.assertAlmostEqual(system.site_percentages()["F"], 75.0, places=8)
 
-    def test_fixed_concentration_exceeding_sites_is_not_reported(self):
-        # A fixed concentration above the site budget cannot be hosted: the
-        # solve raises rather than returning an occupancy above 100%.
-        species = DefectSpecies(
-            "F",
-            nsites=2,
-            charge_states=[DefectChargeState(charge=0, energy=-0.5, degeneracy=1)],
-            fixed_concentration=5.0,
-        )
-        system = DefectSystem(
-            defect_species=[species],
-            dos=self.dos,
-            volume=100,
-            temperature=300,
-        )
-        with self.assertRaises(RuntimeError):
-            system.site_percentages()
-
     def test_mixed_pooled_and_unpooled_species_use_their_own_denominators(self):
         # A pooled species is divided by the pool size; an unpooled species in
         # the same system is divided by its own nsites.


### PR DESCRIPTION
## Summary

`DefectSystem.site_percentages` computed each species' occupancy from the unbounded dilute Boltzmann expression (`DefectSpecies.get_concentration` divided by `nsites`), which ignores site-exclusion statistics and `site_pools`/`element_pools` competition. A near-saturation or pooled species could therefore report occupancies far above 100% (for example ~2.5e10% for a low-energy species), contradicting the concentrations reported by `report` and `concentration_dict`.

The occupancies are now taken from `_global_defect_concs` at the self-consistent Fermi level -- the same source of truth the rest of the class uses -- and each species' total is divided by the sites available to it: its own `nsites`, or, for a species in a `site_pools` entry, that pool's total site count (so a pool's members together occupy at most 100% of it). A species' concentration cannot exceed its available sites -- a fixed concentration over the site budget is rejected at construction rather than being reported -- so every reported occupancy is at most 100%.

The method signature and return type are unchanged.