### PR TITLE
Validate fixed-concentration consistency at construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,14 @@
   names interchangeably (both are normalised to names internally).
   `DefectSystem.defect_species_by_name` now raises a `ValueError` listing the
   available names, rather than an `IndexError`, when given an unknown name.
+- Fixed concentrations are validated against their site budget at
+  construction: a `ValueError` is raised if the total fixed concentration in a
+  site-exclusion group exceeds its available sites (an unpooled species' own
+  `nsites`, or a `site_pools` entry's shared size). Whether the fixed
+  concentrations fit is independent of the Fermi level, so this previously
+  surfaced only when solving, wrapped as a `RuntimeError` about the
+  Fermi-energy search window; it now fails fast at construction with a message
+  naming the group and the budget versus the occupancy.
 - Added band-edge corrections (`vbm_shift`, `cbm_shift`,
   `formation_energy_corrections`, `rigid_shift`) to `DefectSystem`. `vbm_shift`
   and `cbm_shift` are pre-evaluated shifts (in eV) used to compute the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,14 +71,14 @@
   names interchangeably (both are normalised to names internally).
   `DefectSystem.defect_species_by_name` now raises a `ValueError` listing the
   available names, rather than an `IndexError`, when given an unknown name.
-- Fixed concentrations are validated against their site budget at
-  construction: a `ValueError` is raised if the total fixed concentration in a
+- Fixed concentrations are validated at construction: a `ValueError` is raised
+  if a species' individually-fixed charge states together exceed its
+  species-level `fixed_concentration`, or if the total fixed concentration in a
   site-exclusion group exceeds its available sites (an unpooled species' own
-  `nsites`, or a `site_pools` entry's shared size). Whether the fixed
-  concentrations fit is independent of the Fermi level, so this previously
-  surfaced only when solving, wrapped as a `RuntimeError` about the
-  Fermi-energy search window; it now fails fast at construction with a message
-  naming the group and the budget versus the occupancy.
+  `nsites`, or a `site_pools` entry's shared size). Both conditions are
+  independent of the Fermi level, so they previously surfaced only when
+  solving, wrapped as a `RuntimeError` about the Fermi-energy search window;
+  they now fail fast at construction with a clear message.
 - Added band-edge corrections (`vbm_shift`, `cbm_shift`,
   `formation_energy_corrections`, `rigid_shift`) to `DefectSystem`. `vbm_shift`
   and `cbm_shift` are pre-evaluated shifts (in eV) used to compute the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,14 +71,16 @@
   names interchangeably (both are normalised to names internally).
   `DefectSystem.defect_species_by_name` now raises a `ValueError` listing the
   available names, rather than an `IndexError`, when given an unknown name.
-- Fixed concentrations are validated at construction: a `ValueError` is raised
-  if a species' individually-fixed charge states together exceed its
-  species-level `fixed_concentration`, or if the total fixed concentration in a
-  site-exclusion group exceeds its available sites (an unpooled species' own
-  `nsites`, or a `site_pools` entry's shared size). Both conditions are
-  independent of the Fermi level, so they previously surfaced only when
-  solving, wrapped as a `RuntimeError` about the Fermi-energy search window;
-  they now fail fast at construction with a clear message.
+- Fixed concentrations are validated at construction. A `ValueError` is raised
+  if a species' individually-fixed charge states are inconsistent with its
+  species-level `fixed_concentration` -- they exceed it, or, when every charge
+  state is fixed so none can absorb a shortfall, fall below it -- or if the
+  total fixed concentration in a site-exclusion group exceeds its available
+  sites (an unpooled species' own `nsites`, or a `site_pools` entry's shared
+  size). These conditions are all independent of the Fermi level; they
+  previously surfaced only at solve time (wrapped as a `RuntimeError` about the
+  Fermi-energy search window) or, for a shortfall, were silently under-reported.
+  They now fail fast at construction with a clear message.
 - Added band-edge corrections (`vbm_shift`, `cbm_shift`,
   `formation_energy_corrections`, `rigid_shift`) to `DefectSystem`. `vbm_shift`
   and `cbm_shift` are pre-evaluated shifts (in eV) used to compute the

--- a/py_sc_fermi/defect_species.py
+++ b/py_sc_fermi/defect_species.py
@@ -497,7 +497,13 @@ class DefectSpecies:
             ]
             fixed_conc_total = sum(c for (cs, c) in results if cs.fixed_concentration is not None)
             constrained_conc = self.fixed_concentration - fixed_conc_total
-            if constrained_conc < 0:
+            if math.isclose(fixed_conc_total, self.fixed_concentration):
+                # Fixed charge states already account for the whole species
+                # total (up to floating-point noise); leave no remainder, so
+                # the variable-state rescale below cannot produce a tiny
+                # negative concentration.
+                constrained_conc = 0.0
+            elif constrained_conc < 0:
                 raise ValueError(
                     f"Fixed charge state concentrations ({fixed_conc_total}) exceed "
                     f"total species concentration ({self.fixed_concentration})"
@@ -512,7 +518,7 @@ class DefectSpecies:
                 log_total = logsumexp(log_weights)
                 for (idx, cs), log_w in zip(var_states, log_weights, strict=True):
                     results[idx] = (cs, np.exp(log_w - log_total) * constrained_conc)
-            elif not math.isclose(fixed_conc_total, self.fixed_concentration):
+            elif constrained_conc > 0:
                 raise ValueError(
                     f"Fixed charge state concentrations ({fixed_conc_total}) are "
                     f"below total species concentration ({self.fixed_concentration}) "

--- a/py_sc_fermi/defect_species.py
+++ b/py_sc_fermi/defect_species.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 import numpy as np
 from scipy.constants import physical_constants
 from scipy.special import logsumexp
@@ -510,6 +512,12 @@ class DefectSpecies:
                 log_total = logsumexp(log_weights)
                 for (idx, cs), log_w in zip(var_states, log_weights, strict=True):
                     results[idx] = (cs, np.exp(log_w - log_total) * constrained_conc)
+            elif not math.isclose(fixed_conc_total, self.fixed_concentration):
+                raise ValueError(
+                    f"Fixed charge state concentrations ({fixed_conc_total}) are "
+                    f"below total species concentration ({self.fixed_concentration}) "
+                    "with no variable charge state to make up the difference"
+                )
 
         return results
 

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import math
 from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -353,25 +354,36 @@ class DefectSystem:
         properties of the system, caught here at construction rather than left
         to surface (wrapped as a Fermi-window error) from a later solve:
 
-        * within a species fixed at the total level, its individually-fixed
-          charge states cannot together exceed that total; and
+        * a species fixed at the total level must be consistent with its
+          individually-fixed charge states: those cannot exceed the total, and
+          if every charge state is fixed (none variable) they must sum to it,
+          since there is then nothing to make up any shortfall; and
         * within a site-exclusion group, the members' total fixed
           concentration cannot exceed the group's site budget.
 
         Raises:
-            ValueError: if a species' fixed charge states exceed its
-                species-level fixed concentration, or a group's total fixed
+            ValueError: if a species' fixed charge states are inconsistent with
+                its species-level fixed concentration, or a group's total fixed
                 concentration exceeds its site budget (its ``site_pools`` size,
                 or, for an unpooled species, its own ``nsites``).
         """
         for sp in self.defect_species:
-            if sp.fixed_concentration is not None:
-                charge_state_total = self._charge_state_fixed_total(sp)
-                if charge_state_total > sp.fixed_concentration:
-                    raise ValueError(
-                        f"'{sp.name}' is fixed at {sp.fixed_concentration} but "
-                        f"its fixed charge states require {charge_state_total}"
-                    )
+            if sp.fixed_concentration is None:
+                continue
+            charge_state_total = self._charge_state_fixed_total(sp)
+            if math.isclose(charge_state_total, sp.fixed_concentration):
+                continue
+            if charge_state_total > sp.fixed_concentration:
+                raise ValueError(
+                    f"'{sp.name}' is fixed at {sp.fixed_concentration} but its "
+                    f"fixed charge states require {charge_state_total}"
+                )
+            if all(cs.fixed_concentration is not None for cs in sp.charge_states):
+                raise ValueError(
+                    f"'{sp.name}' is fixed at {sp.fixed_concentration} but its "
+                    f"fixed charge states sum to {charge_state_total}, with no "
+                    f"variable charge state to make up the difference"
+                )
 
         for label, n_sites, species in self._exclusion_group_specs():
             fixed_total = sum((self._fixed_total(sp) for sp in species), 0.0)

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -254,6 +254,7 @@ class DefectSystem:
         self.element_pools: ElementPools = _normalise_element_pools(element_pools)
 
         self._validate_pools()
+        self._validate_fixed_concentrations()
 
     def _apply_formation_energy_corrections(
         self,
@@ -343,6 +344,42 @@ class DefectSystem:
                 f"{kind} '{pool_name}' lists species more than once: "
                 f"{', '.join(repeated)}"
             )
+
+    def _validate_fixed_concentrations(self) -> None:
+        """Reject fixed concentrations that exceed their site-exclusion group's
+        site budget.
+
+        Whether the fixed concentrations fit is independent of the Fermi level
+        -- it depends only on the fixed concentrations and the group site
+        budgets -- so it is a static property of the system, checked here at
+        construction rather than left to surface from a later solve.
+
+        Raises:
+            ValueError: if any group's total fixed concentration exceeds its
+                site budget (its ``site_pools`` size, or, for an unpooled
+                species, its own ``nsites``).
+        """
+        for label, n_sites, species in self._exclusion_group_specs():
+            fixed_total = sum((self._fixed_total(sp) for sp in species), 0.0)
+            if fixed_total > n_sites:
+                raise ValueError(
+                    f"'{label}' has {n_sites} sites but fixed-concentration "
+                    f"states occupy {fixed_total}"
+                )
+
+    @staticmethod
+    def _fixed_total(species: DefectSpecies) -> float:
+        """Total fixed concentration ``species`` contributes to its group's
+        occupancy: its species-level ``fixed_concentration`` if set, otherwise
+        the sum of its charge states' fixed concentrations.
+        """
+        if species.fixed_concentration is not None:
+            return species.fixed_concentration
+        total = 0.0
+        for cs in species.charge_states:
+            if cs.fixed_concentration is not None:
+                total += cs.fixed_concentration
+        return total
 
     def __repr__(self) -> str:
         bandgap = self.dos.bandgap + (self.cbm_shift - self.vbm_shift)
@@ -458,7 +495,6 @@ class DefectSystem:
 
     def _build_group(
         self,
-        label: str,
         n_sites: float,
         species: list[DefectSpecies],
         e_fermi: float,
@@ -467,34 +503,45 @@ class DefectSystem:
         """Build an exclusion group of `n_sites` sites shared by `species`.
 
         Species-level `fixed_concentration` and individually-fixed charge
-        states are written into `fixed_concs` and subtracted from `n_sites`
-        to give the group's free-site budget; every other charge state
-        becomes a variable state of the group.
+        states are written into `fixed_concs`; every other charge state
+        becomes a variable state of the group. The free-site budget is
+        `n_sites` minus the group's total fixed concentration, which
+        `_validate_fixed_concentrations` guarantees is non-negative at
+        construction.
         """
-        fixed_total = 0.0
         variable_states: list[_VariableState] = []
         for sp in species:
             if sp.fixed_concentration is not None:
-                fixed_total += sp.fixed_concentration
                 for cs, conc in sp.charge_state_concentrations(e_fermi, self.temperature):
                     fixed_concs[cs] = conc
                 continue
             for cs in sp.charge_states:
                 if cs.fixed_concentration is not None:
                     fixed_concs[cs] = cs.fixed_concentration
-                    fixed_total += cs.fixed_concentration
                 else:
                     Ef = cs.get_formation_energy(e_fermi)
                     log_w = np.log(cs.degeneracy) - Ef / (_kboltz * self.temperature)
                     variable_states.append(_VariableState(cs, sp, log_w))
 
-        n_free = n_sites - fixed_total
-        if n_free < 0:
-            raise ValueError(
-                f"'{label}' has {n_sites} sites but fixed-concentration "
-                f"states occupy {fixed_total}"
-            )
+        n_free = n_sites - sum((self._fixed_total(sp) for sp in species), 0.0)
         return _ExclusionGroup(n_free=n_free, variable_states=variable_states)
+
+    def _exclusion_group_specs(self) -> list[tuple[str, float, list[DefectSpecies]]]:
+        """Enumerate the site-exclusion groups as
+        ``(label, site budget, member species)``: one group per `site_pools`
+        entry (its pool size and members), plus an implicit single-species
+        group of `nsites` for every species not in a site pool.
+        """
+        specs: list[tuple[str, float, list[DefectSpecies]]] = []
+        pooled_species: set[DefectSpecies] = set()
+        for pool_name, (n_pool, species_list) in self.site_pools.items():
+            sp_objs = [self._resolve_species(name) for name in species_list]
+            pooled_species.update(sp_objs)
+            specs.append((pool_name, n_pool, sp_objs))
+        for sp in self.defect_species:
+            if sp not in pooled_species:
+                specs.append((sp.name, sp.nsites, [sp]))
+        return specs
 
     def _build_exclusion_groups(
         self, e_fermi: float
@@ -512,17 +559,8 @@ class DefectSystem:
         """
         groups: list[_ExclusionGroup] = []
         fixed_concs: dict[DefectChargeState, float] = {}
-        pooled_species: set[DefectSpecies] = set()
-
-        for pool_name, (n_pool, species_list) in self.site_pools.items():
-            sp_objs = [self._resolve_species(name) for name in species_list]
-            pooled_species.update(sp_objs)
-            groups.append(self._build_group(pool_name, n_pool, sp_objs, e_fermi, fixed_concs))
-
-        for sp in self.defect_species:
-            if sp not in pooled_species:
-                groups.append(self._build_group(sp.name, sp.nsites, [sp], e_fermi, fixed_concs))
-
+        for _, n_sites, species in self._exclusion_group_specs():
+            groups.append(self._build_group(n_sites, species, e_fermi, fixed_concs))
         return groups, fixed_concs
 
     def _resolve_element_pools(self) -> ElementPoolsResolved:

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -346,19 +346,33 @@ class DefectSystem:
             )
 
     def _validate_fixed_concentrations(self) -> None:
-        """Reject fixed concentrations that exceed their site-exclusion group's
-        site budget.
+        """Reject fixed concentrations that cannot be hosted.
 
-        Whether the fixed concentrations fit is independent of the Fermi level
-        -- it depends only on the fixed concentrations and the group site
-        budgets -- so it is a static property of the system, checked here at
-        construction rather than left to surface from a later solve.
+        Both checks are independent of the Fermi level -- they depend only on
+        the fixed concentrations and the site budgets -- so they are static
+        properties of the system, caught here at construction rather than left
+        to surface (wrapped as a Fermi-window error) from a later solve:
+
+        * within a species fixed at the total level, its individually-fixed
+          charge states cannot together exceed that total; and
+        * within a site-exclusion group, the members' total fixed
+          concentration cannot exceed the group's site budget.
 
         Raises:
-            ValueError: if any group's total fixed concentration exceeds its
-                site budget (its ``site_pools`` size, or, for an unpooled
-                species, its own ``nsites``).
+            ValueError: if a species' fixed charge states exceed its
+                species-level fixed concentration, or a group's total fixed
+                concentration exceeds its site budget (its ``site_pools`` size,
+                or, for an unpooled species, its own ``nsites``).
         """
+        for sp in self.defect_species:
+            if sp.fixed_concentration is not None:
+                charge_state_total = self._charge_state_fixed_total(sp)
+                if charge_state_total > sp.fixed_concentration:
+                    raise ValueError(
+                        f"'{sp.name}' is fixed at {sp.fixed_concentration} but "
+                        f"its fixed charge states require {charge_state_total}"
+                    )
+
         for label, n_sites, species in self._exclusion_group_specs():
             fixed_total = sum((self._fixed_total(sp) for sp in species), 0.0)
             if fixed_total > n_sites:
@@ -368,6 +382,17 @@ class DefectSystem:
                 )
 
     @staticmethod
+    def _charge_state_fixed_total(species: DefectSpecies) -> float:
+        """Sum of the explicit fixed concentrations of ``species``' charge
+        states (zero if none are individually fixed).
+        """
+        total = 0.0
+        for cs in species.charge_states:
+            if cs.fixed_concentration is not None:
+                total += cs.fixed_concentration
+        return total
+
+    @staticmethod
     def _fixed_total(species: DefectSpecies) -> float:
         """Total fixed concentration ``species`` contributes to its group's
         occupancy: its species-level ``fixed_concentration`` if set, otherwise
@@ -375,11 +400,7 @@ class DefectSystem:
         """
         if species.fixed_concentration is not None:
             return species.fixed_concentration
-        total = 0.0
-        for cs in species.charge_states:
-            if cs.fixed_concentration is not None:
-                total += cs.fixed_concentration
-        return total
+        return DefectSystem._charge_state_fixed_total(species)
 
     def __repr__(self) -> str:
         bandgap = self.dos.bandgap + (self.cbm_shift - self.vbm_shift)

--- a/tests/test_defect_species.py
+++ b/tests/test_defect_species.py
@@ -554,7 +554,18 @@ class TestDefectSpecies(unittest.TestCase):
             charge_states=[cs_0, cs_1]
         )
         defect.fix_concentration(0.1)  # Less than fixed charge state concentration
-        
+
+        with self.assertRaises(ValueError):
+            defect.charge_state_concentrations(e_fermi=0.0, temperature=298)
+
+    def test_charge_state_concentrations_raises_if_below_total_with_no_variable(self):
+        """Should raise ValueError if all charge states are fixed and sum to
+        less than the species total, with no variable state to make up the
+        difference."""
+        cs_0 = DefectChargeState(charge=0, fixed_concentration=3.0)
+        defect = DefectSpecies(name="test", nsites=10, charge_states=[cs_0])
+        defect.fix_concentration(5.0)
+
         with self.assertRaises(ValueError):
             defect.charge_state_concentrations(e_fermi=0.0, temperature=298)
 

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -530,6 +530,75 @@ class TestDefectSystemSitePools(unittest.TestCase):
                 site_pools={"shared": (10.0, [self.species_a, self.species_b])},
             )
 
+    def test_species_fixed_above_all_fixed_charge_states_raises_at_construction(self):
+        # A species pinned at a total its all-fixed charge states cannot reach,
+        # with no variable charge state to make up the difference, is a static
+        # inconsistency; reject it at construction rather than silently
+        # under-reporting the total.
+        species = DefectSpecies(
+            "F",
+            nsites=10,
+            charge_states=[DefectChargeState(charge=0, fixed_concentration=3.0)],
+            fixed_concentration=5.0,
+        )
+        with self.assertRaisesRegex(
+            ValueError, r"'F' is fixed at 5.*sum to 3.*no variable"
+        ):
+            DefectSystem(
+                defect_species=[species],
+                dos=self.dos,
+                volume=100,
+                temperature=300,
+            )
+
+    def test_species_fixed_equal_to_all_fixed_charge_states_is_accepted(self):
+        # All charge states fixed and summing exactly to the species total
+        # (no variable state needed) is consistent: construct and solve.
+        species = DefectSpecies(
+            "F",
+            nsites=10,
+            charge_states=[
+                DefectChargeState(charge=0, fixed_concentration=2.0),
+                DefectChargeState(charge=0, fixed_concentration=3.0),
+            ],
+            fixed_concentration=5.0,
+        )
+        system = DefectSystem(
+            defect_species=[species],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+        )
+        total = sum(
+            system._global_defect_concs(system.get_sc_fermi()[0])[cs]
+            for cs in system.defect_species[0].charge_states
+        )
+        self.assertAlmostEqual(total, 5.0, places=8)
+
+    def test_species_fixed_above_fixed_charge_states_with_variable_succeeds(self):
+        # With a variable charge state to absorb the remainder, a species
+        # total above its fixed charge states is fine.
+        species = DefectSpecies(
+            "F",
+            nsites=10,
+            charge_states=[
+                DefectChargeState(charge=0, fixed_concentration=3.0),
+                DefectChargeState(charge=0, energy=-0.5, degeneracy=1),
+            ],
+            fixed_concentration=5.0,
+        )
+        system = DefectSystem(
+            defect_species=[species],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+        )
+        total = sum(
+            system._global_defect_concs(system.get_sc_fermi()[0])[cs]
+            for cs in system.defect_species[0].charge_states
+        )
+        self.assertAlmostEqual(total, 5.0, places=8)
+
     def test_repr_lists_site_pools_by_name(self):
         system = DefectSystem(
             defect_species=[self.species_a, self.species_b],

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -476,6 +476,60 @@ class TestDefectSystemSitePools(unittest.TestCase):
                 temperature=300,
             )
 
+    def test_species_fixed_below_its_fixed_charge_states_raises_at_construction(self):
+        # A species fixed below the sum of its own fixed charge states is a
+        # static inconsistency, independent of the Fermi level; reject it at
+        # construction rather than wrapped as a Fermi-window error mid-solve.
+        species = DefectSpecies(
+            "F",
+            nsites=10,
+            charge_states=[DefectChargeState(charge=0, fixed_concentration=5.0)],
+            fixed_concentration=1.0,
+        )
+        with self.assertRaisesRegex(ValueError, r"'F' is fixed at 1.*require 5"):
+            DefectSystem(
+                defect_species=[species],
+                dos=self.dos,
+                volume=100,
+                temperature=300,
+            )
+
+    def test_fixed_concentration_equal_to_sites_is_accepted(self):
+        # Exactly saturating the sites (n_free == 0) is valid: the strict ">"
+        # budget check must admit it and the solve must succeed.
+        species = DefectSpecies(
+            "F",
+            nsites=2,
+            charge_states=[DefectChargeState(charge=0, energy=-0.5, degeneracy=1)],
+            fixed_concentration=2.0,
+        )
+        system = DefectSystem(
+            defect_species=[species],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+        )
+        total = sum(
+            system._global_defect_concs(system.get_sc_fermi()[0])[cs]
+            for cs in system.defect_species[0].charge_states
+        )
+        self.assertAlmostEqual(total, 2.0, places=8)
+
+    def test_pool_raises_when_members_jointly_exceed_site_count(self):
+        # Each member fits the pool alone -- A across its two fixed charge
+        # states, B in one -- but together they exceed the shared budget.
+        self.species_a.charge_states[0].fix_concentration(4.0)
+        self.species_a.charge_states[1].fix_concentration(4.0)
+        self.species_b.charge_states[0].fix_concentration(4.0)
+        with self.assertRaises(ValueError):
+            DefectSystem(
+                defect_species=[self.species_a, self.species_b],
+                dos=self.dos,
+                volume=100,
+                temperature=300,
+                site_pools={"shared": (10.0, [self.species_a, self.species_b])},
+            )
+
     def test_repr_lists_site_pools_by_name(self):
         system = DefectSystem(
             defect_species=[self.species_a, self.species_b],

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -41,6 +41,10 @@ class TestDefectSystemInit(unittest.TestCase):
         mock_defect_species[1].name = "O_i"
         mock_defect_species[0].charge_states = []
         mock_defect_species[1].charge_states = []
+        mock_defect_species[0].fixed_concentration = None
+        mock_defect_species[1].fixed_concentration = None
+        mock_defect_species[0].nsites = 1
+        mock_defect_species[1].nsites = 1
         dos = Mock(spec=DOS)
         temperature = 298
         defect_system = DefectSystem(
@@ -67,6 +71,10 @@ class TestDefectSystem(unittest.TestCase):
         mock_defect_species[1].name = "O_i"
         mock_defect_species[0].charge_states = []
         mock_defect_species[1].charge_states = []
+        mock_defect_species[0].fixed_concentration = None
+        mock_defect_species[1].fixed_concentration = None
+        mock_defect_species[0].nsites = 1
+        mock_defect_species[1].nsites = 1
         dos = Mock(spec=DOS)
         dos.spin_polarised = True
         dos._nelect = 12
@@ -405,16 +413,17 @@ class TestDefectSystemSitePools(unittest.TestCase):
         self.assertEqual(system.site_pools, {"shared": (10.0, ["A", "B"])})
 
     def test_pool_raises_when_fixed_concentrations_exceed_site_count(self):
+        # Over-budget fixed concentrations are a static constraint violation,
+        # rejected at construction rather than surfacing from the solve.
         self.species_a.charge_states[0].fix_concentration(20.0)
-        system = DefectSystem(
-            defect_species=[self.species_a],
-            dos=self.dos,
-            volume=100,
-            temperature=300,
-            site_pools={"shared": (10.0, [self.species_a])},
-        )
         with self.assertRaises(ValueError):
-            system._global_defect_concs(1.0)
+            DefectSystem(
+                defect_species=[self.species_a],
+                dos=self.dos,
+                volume=100,
+                temperature=300,
+                site_pools={"shared": (10.0, [self.species_a])},
+            )
 
     def test_pooled_species_honours_species_level_fixed_concentration(self):
         self.species_a.fix_concentration(3.0)
@@ -446,15 +455,26 @@ class TestDefectSystemSitePools(unittest.TestCase):
         self,
     ):
         self.species_a.fix_concentration(20.0)
-        system = DefectSystem(
-            defect_species=[self.species_a],
-            dos=self.dos,
-            volume=100,
-            temperature=300,
-            site_pools={"shared": (10.0, [self.species_a])},
-        )
         with self.assertRaises(ValueError):
-            system._global_defect_concs(1.0)
+            DefectSystem(
+                defect_species=[self.species_a],
+                dos=self.dos,
+                volume=100,
+                temperature=300,
+                site_pools={"shared": (10.0, [self.species_a])},
+            )
+
+    def test_unpooled_species_raises_when_fixed_concentration_exceeds_nsites(self):
+        # An unpooled species' implicit group budget is its own nsites; the
+        # error names the species and the budget-versus-occupancy.
+        self.species_a.fix_concentration(20.0)  # nsites=5
+        with self.assertRaisesRegex(ValueError, r"'A' has 5 .*occupy 20"):
+            DefectSystem(
+                defect_species=[self.species_a],
+                dos=self.dos,
+                volume=100,
+                temperature=300,
+            )
 
     def test_repr_lists_site_pools_by_name(self):
         system = DefectSystem(
@@ -1851,7 +1871,7 @@ class TestDefectSystemPoolSerialisation(unittest.TestCase):
                     degeneracy=np.float64(1),
                 ),
                 DefectChargeState(
-                    charge=np.int64(1), fixed_concentration=np.float64(1e19)
+                    charge=np.int64(1), fixed_concentration=np.float64(2.0)
                 ),
             ],
         )

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -552,16 +552,18 @@ class TestDefectSystemSitePools(unittest.TestCase):
             )
 
     def test_species_fixed_equal_to_all_fixed_charge_states_is_accepted(self):
-        # All charge states fixed and summing exactly to the species total
-        # (no variable state needed) is consistent: construct and solve.
+        # All charge states fixed and summing to the species total -- within
+        # floating-point noise, since 0.1 + 0.2 != 0.3 in binary -- is
+        # consistent: construct AND solve must both succeed, exercising the
+        # isclose tolerance through the whole path, not just construction.
         species = DefectSpecies(
             "F",
             nsites=10,
             charge_states=[
-                DefectChargeState(charge=0, fixed_concentration=2.0),
-                DefectChargeState(charge=0, fixed_concentration=3.0),
+                DefectChargeState(charge=0, fixed_concentration=0.1),
+                DefectChargeState(charge=0, fixed_concentration=0.2),
             ],
-            fixed_concentration=5.0,
+            fixed_concentration=0.3,
         )
         system = DefectSystem(
             defect_species=[species],
@@ -573,7 +575,7 @@ class TestDefectSystemSitePools(unittest.TestCase):
             system._global_defect_concs(system.get_sc_fermi()[0])[cs]
             for cs in system.defect_species[0].charge_states
         )
-        self.assertAlmostEqual(total, 5.0, places=8)
+        self.assertAlmostEqual(total, 0.3, places=8)
 
     def test_species_fixed_above_fixed_charge_states_with_variable_succeeds(self):
         # With a variable charge state to absorb the remainder, a species


### PR DESCRIPTION
## Summary

Several fixed-concentration inconsistencies are static -- they depend only on the fixed concentrations, the site budgets, and which charge states are variable, not on the Fermi level -- yet they were only caught mid-solve, where they surfaced as `RuntimeError: No solution found between ...` (mis-attributing a constraint violation to the Fermi-energy search window) or, in one case, were silently under-reported. This validates them up front in `DefectSystem._validate_fixed_concentrations`, so they fail fast at construction with a clear, unwrapped message.

The checks:

- **Group site budget.** The total fixed concentration in a site-exclusion group cannot exceed its site budget -- an unpooled species' own `nsites`, or a `site_pools` entry's shared pool size.
- **Intra-species, over-determined.** A species' individually-fixed charge states cannot sum to more than its species-level `fixed_concentration`.
- **Intra-species, unreachable total.** If every charge state of a species is individually fixed (none variable to absorb a shortfall), they must sum to the species-level `fixed_concentration`; previously a shortfall was silently under-reported by `charge_state_concentrations`.

Implementation notes: the group enumeration is factored into `_exclusion_group_specs` (shared with `_build_exclusion_groups`) and the per-species fixed total into `_fixed_total` / `_charge_state_fixed_total`. The now-redundant `n_free < 0` raise is removed from `_build_group`. `DefectSpecies.charge_state_concentrations` keeps (and, for the shortfall case, gains) its own guard for direct callers. Species-level consistency comparisons use `math.isclose`, so a redundant-but-consistent fixed total (charge states summing to the species total up to floating-point noise) is accepted.