### PR TITLE
Add fixed_concentrations override to the DefectSystem constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,9 @@
   `DefectSystem.defect_species_by_name` now raises a `ValueError` listing the
   available names, rather than an `IndexError`, when given an unknown name.
 - Fixed concentrations are validated at construction. A `ValueError` is raised
-  if a species' individually-fixed charge states are inconsistent with its
+  if a species-level `fixed_concentration` is not a finite, non-negative number
+  (a NaN would otherwise pass silently into the solved concentrations), if a
+  species' individually-fixed charge states are inconsistent with its
   species-level `fixed_concentration` -- they exceed it, or, when every charge
   state is fixed so none can absorb a shortfall, fall below it -- or if the
   total fixed concentration in a site-exclusion group exceeds its available
@@ -108,7 +110,7 @@
   mapping species name to a fixed total concentration per unit cell, applied by
   name to the constructor's own copies of `defect_species` (overriding any
   species-level `fixed_concentration` they were constructed with, and composing
-  with `formation_energy_corrections`, which resolve by identity). This makes
+  with `formation_energy_corrections`, which are resolved by identity). This makes
   the anneal-and-quench override documented on `DefectSystemFactory.at` work:
   freeze some species' totals at their high-temperature values and re-solve at
   a lower temperature, e.g.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,15 @@
   **overrides)` evaluates these functions at `T` and returns an independent
   `DefectSystem`, e.g. `{T: factory.at(T).concentration_dict() for T in
   temperatures}`.
+- `DefectSystem` gained a `fixed_concentrations` argument: a `dict[str, float]`
+  mapping species name to a fixed total concentration per unit cell, applied by
+  name to the constructor's own copies of `defect_species` (overriding any
+  species-level `fixed_concentration` they were constructed with, and composing
+  with `formation_energy_corrections`, which resolve by identity). This makes
+  the anneal-and-quench override documented on `DefectSystemFactory.at` work:
+  freeze some species' totals at their high-temperature values and re-solve at
+  a lower temperature, e.g.
+  `factory.at(T_low, fixed_concentrations={n: high[n] for n in frozen})`.
 
 ### Bug Fixes
 

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -212,10 +212,11 @@ class DefectSystem:
           with. The fix is applied by name to this system's own copies of
           `defect_species`, so it composes with `formation_energy_corrections`
           (resolved by identity against the passed-in objects) and never
-          mutates the caller's species. A value that cannot be hosted (above
-          the species' available sites, or below its individually-fixed charge
-          states) is rejected at construction by the same checks as a
-          species-level fix. Defaults to None (no fixes).
+          mutates the caller's species. A non-finite or negative value, or one
+          that cannot be hosted (above its site-exclusion group's site budget
+          -- its own `nsites`, or its shared `site_pools` size -- or below its
+          individually-fixed charge states), is rejected at construction by the
+          same checks as a species-level fix. Defaults to None (no fixes).
 
     Raises:
         ValueError: if two entries in `defect_species` share a name, a pool
@@ -278,10 +279,8 @@ class DefectSystem:
 
         Each ``name -> conc`` entry sets the species-level
         ``fixed_concentration`` of the matching copy in ``self.defect_species``,
-        overriding any species-level fix it was constructed with. Resolving by
-        name on the copies keeps this independent of
-        ``formation_energy_corrections``, which are resolved by identity against
-        the originals. The now-fixed copies are validated by
+        overriding any species-level fix it was constructed with. The copies
+        are resolved by name (never the caller's originals) and validated by
         ``_validate_fixed_concentrations``.
 
         Raises:
@@ -381,13 +380,16 @@ class DefectSystem:
             )
 
     def _validate_fixed_concentrations(self) -> None:
-        """Reject fixed concentrations that cannot be hosted.
+        """Reject fixed concentrations that are invalid or cannot be hosted.
 
-        Both checks are independent of the Fermi level -- they depend only on
+        The checks are independent of the Fermi level -- they depend only on
         the fixed concentrations and the site budgets -- so they are static
         properties of the system, caught here at construction rather than left
         to surface (wrapped as a Fermi-window error) from a later solve:
 
+        * a species-level fixed concentration must be a finite, non-negative
+          number (a NaN would otherwise pass every comparison below and
+          surface silently as ``nan`` in the solved concentrations);
         * a species fixed at the total level must be consistent with its
           individually-fixed charge states: those cannot exceed the total, and
           if every charge state is fixed (none variable) they must sum to it,
@@ -396,14 +398,21 @@ class DefectSystem:
           concentration cannot exceed the group's site budget.
 
         Raises:
-            ValueError: if a species' fixed charge states are inconsistent with
-                its species-level fixed concentration, or a group's total fixed
-                concentration exceeds its site budget (its ``site_pools`` size,
-                or, for an unpooled species, its own ``nsites``).
+            ValueError: if a species-level fixed concentration is not finite
+                and non-negative, a species' fixed charge states are
+                inconsistent with its species-level fixed concentration, or a
+                group's total fixed concentration exceeds its site budget (its
+                ``site_pools`` size, or, for an unpooled species, its own
+                ``nsites``).
         """
         for sp in self.defect_species:
             if sp.fixed_concentration is None:
                 continue
+            if not math.isfinite(sp.fixed_concentration) or sp.fixed_concentration < 0:
+                raise ValueError(
+                    f"'{sp.name}' has an invalid fixed concentration "
+                    f"{sp.fixed_concentration}; it must be finite and non-negative"
+                )
             charge_state_total = self._charge_state_fixed_total(sp)
             if math.isclose(charge_state_total, sp.fixed_concentration):
                 continue

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -205,21 +205,33 @@ class DefectSystem:
           defect levels are fixed in absolute energy while the band edges
           move, so such charge states have their formation energy shifted by
           `-charge * vbm_shift`.
+        fixed_concentrations (dict[str, float] | None, optional): mapping of
+          species name -> fixed total concentration (per unit cell). Each
+          named species has its total concentration fixed at the given value,
+          overriding any species-level `fixed_concentration` it was constructed
+          with. The fix is applied by name to this system's own copies of
+          `defect_species`, so it composes with `formation_energy_corrections`
+          (resolved by identity against the passed-in objects) and never
+          mutates the caller's species. A value that cannot be hosted (above
+          the species' available sites, or below its individually-fixed charge
+          states) is rejected at construction by the same checks as a
+          species-level fix. Defaults to None (no fixes).
 
     Raises:
         ValueError: if two entries in `defect_species` share a name, a pool
           references a species not in `defect_species`, a pool lists a
           species more than once, a species appears in more than one site
-          pool, or `formation_energy_corrections` references a
-          `DefectChargeState` that is not part of `defect_species`.
+          pool, `formation_energy_corrections` references a `DefectChargeState`
+          that is not part of `defect_species`, or `fixed_concentrations` names
+          a species not in `defect_species`.
 
     Note:
         `DefectSystem` is an immutable, fixed-temperature snapshot:
-        `vbm_shift`, `cbm_shift`, `formation_energy_corrections`, and
-        `rigid_shift` are evaluated once at construction and applied to
-        copies of `defect_species` -- the objects passed in (including any
-        `formation_energy_corrections` keys) are never modified, even
-        temporarily. To build `DefectSystem`s at several temperatures from
+        `vbm_shift`, `cbm_shift`, `formation_energy_corrections`,
+        `rigid_shift`, and `fixed_concentrations` are applied once at
+        construction to copies of `defect_species` -- the objects passed in
+        (including any `formation_energy_corrections` keys) are never modified,
+        even temporarily. To build `DefectSystem`s at several temperatures from
         temperature-dependent shift/correction functions, see
         `DefectSystemFactory`.
     """
@@ -237,6 +249,7 @@ class DefectSystem:
         cbm_shift: float = 0.0,
         formation_energy_corrections: dict[DefectChargeState, float] | None = None,
         rigid_shift: bool = True,
+        fixed_concentrations: dict[str, float] | None = None,
     ):
         self.volume = volume
         self.dos = dos
@@ -255,7 +268,28 @@ class DefectSystem:
         self.element_pools: ElementPools = _normalise_element_pools(element_pools)
 
         self._validate_pools()
+        self._apply_fixed_concentrations(fixed_concentrations or {})
         self._validate_fixed_concentrations()
+
+    def _apply_fixed_concentrations(
+        self, fixed_concentrations: dict[str, float]
+    ) -> None:
+        """Fix the total concentration of named species on the deep copies.
+
+        Each ``name -> conc`` entry sets the species-level
+        ``fixed_concentration`` of the matching copy in ``self.defect_species``,
+        overriding any species-level fix it was constructed with. Resolving by
+        name on the copies keeps this independent of
+        ``formation_energy_corrections``, which are resolved by identity against
+        the originals. The now-fixed copies are validated by
+        ``_validate_fixed_concentrations``.
+
+        Raises:
+            ValueError: if a name is not in the species roster (via
+                ``defect_species_by_name``, listing the available names).
+        """
+        for name, conc in fixed_concentrations.items():
+            self.defect_species_by_name(name).fix_concentration(conc)
 
     def _apply_formation_energy_corrections(
         self,
@@ -1174,8 +1208,12 @@ class DefectSystemFactory:
               `DefectSystem`.
             **overrides: keyword arguments forwarded to `DefectSystem.__init__`,
               overriding any of this factory's corresponding attributes (e.g.
-              `fixed_concentrations` on individual `DefectSpecies`, or
-              `temperature` itself).
+              `temperature` itself, or `fixed_concentrations`, a
+              `dict[str, float]` mapping species name to a fixed total
+              concentration per unit cell). Passing `fixed_concentrations`
+              freezes those species' totals at the given values, as in the
+              anneal-and-quench workflow: take the totals solved at a high
+              temperature and re-solve at a lower one with them held fixed.
 
         Returns:
             DefectSystem: a new, independent `DefectSystem` for `temperature`.

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -2283,6 +2283,84 @@ class TestDefectSystemFixedConcentrations(unittest.TestCase):
                 fixed_concentrations={"X": 5.0},
             )
 
+    def test_nan_fixed_concentration_raises_at_construction(self):
+        # a charge-neutral species never enters charge neutrality, so without
+        # the guard a NaN survives the solve and surfaces silently as nan.
+        neutral = DefectSpecies(
+            "N", 1, [DefectChargeState(charge=0, energy=0.5, degeneracy=1)]
+        )
+        with self.assertRaises(ValueError) as ctx:
+            DefectSystem(
+                defect_species=[neutral],
+                dos=self.dos,
+                volume=100,
+                temperature=300,
+                fixed_concentrations={"N": float("nan")},
+            )
+        self.assertIn("N", str(ctx.exception))
+        self.assertIn("finite", str(ctx.exception))
+
+    def test_negative_fixed_concentration_raises_with_clear_message(self):
+        with self.assertRaises(ValueError) as ctx:
+            DefectSystem(
+                defect_species=[self._donor("X")],
+                dos=self.dos,
+                volume=100,
+                temperature=300,
+                fixed_concentrations={"X": -0.01},
+            )
+        message = str(ctx.exception)
+        self.assertIn("X", message)
+        self.assertIn("non-negative", message)
+
+    def test_overrides_a_constructed_species_level_fixed_concentration(self):
+        species = DefectSpecies(
+            "X",
+            nsites=1,
+            charge_states=[DefectChargeState(charge=1, energy=0.5, degeneracy=1)],
+            fixed_concentration=0.05,
+        )
+        system = DefectSystem(
+            defect_species=[species],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+            fixed_concentrations={"X": 0.01},
+        )
+        self.assertEqual(system.defect_species_by_name("X").fixed_concentration, 0.01)
+        self.assertAlmostEqual(
+            system.concentration_dict(per_volume=False)["X"], 0.01
+        )
+
+    def test_fixes_multiple_species_in_one_call(self):
+        system = DefectSystem(
+            defect_species=[self._donor("X", energy=0.5), self._donor("Y", energy=0.7)],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+            fixed_concentrations={"X": 0.01, "Y": 0.02},
+        )
+        cd = system.concentration_dict(per_volume=False)
+        self.assertAlmostEqual(cd["X"], 0.01)
+        self.assertAlmostEqual(cd["Y"], 0.02)
+
+    def test_pooled_fix_exceeding_pool_budget_raises_naming_the_pool(self):
+        a = DefectSpecies(
+            "A", 5, [DefectChargeState(charge=0, energy=1.0, degeneracy=1)]
+        )
+        b = DefectSpecies(
+            "B", 5, [DefectChargeState(charge=0, energy=1.0, degeneracy=1)]
+        )
+        with self.assertRaisesRegex(ValueError, "shared"):
+            DefectSystem(
+                defect_species=[a, b],
+                dos=self.dos,
+                volume=100,
+                temperature=300,
+                site_pools={"shared": (1.0, ["A", "B"])},
+                fixed_concentrations={"A": 0.7, "B": 0.5},
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -2146,5 +2146,143 @@ class TestDefectSystemPoolSerialisation(unittest.TestCase):
         yaml.safe_dump(system.as_dict())
 
 
+class TestDefectSystemFixedConcentrations(unittest.TestCase):
+    def setUp(self):
+        self.dos = DOS(
+            dos=np.ones(101),
+            edos=np.linspace(-5.0, 5.0, 101),
+            bandgap=2.0,
+            nelect=10,
+        )
+
+    def _donor(self, name="X", energy=0.5, nsites=1):
+        return DefectSpecies(
+            name=name,
+            nsites=nsites,
+            charge_states=[DefectChargeState(charge=1, energy=energy, degeneracy=1)],
+        )
+
+    def test_constructor_fixes_species_total_by_name(self):
+        species = self._donor("X")
+        system = DefectSystem(
+            defect_species=[species],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+            fixed_concentrations={"X": 0.01},
+        )
+        self.assertAlmostEqual(
+            system.concentration_dict(per_volume=False)["X"], 0.01
+        )
+        self.assertEqual(system.defect_species_by_name("X").fixed_concentration, 0.01)
+
+    def test_factory_at_fixes_species_total_by_name(self):
+        factory = DefectSystemFactory(
+            defect_species=[self._donor("X")], dos=self.dos, volume=100
+        )
+        system = factory.at(300, fixed_concentrations={"X": 0.01})
+        self.assertAlmostEqual(
+            system.concentration_dict(per_volume=False)["X"], 0.01
+        )
+        self.assertEqual(system.defect_species_by_name("X").fixed_concentration, 0.01)
+
+    def test_anneal_and_quench_freezes_some_species_and_re_equilibrates_rest(self):
+        # A minority donor frozen at its high-temperature total, plus a major
+        # donor/acceptor pair that re-equilibrates when the temperature drops.
+        frozen = self._donor("X_frozen", energy=1.5)
+        donor = self._donor("D", energy=0.5)
+        acceptor = DefectSpecies(
+            name="A",
+            nsites=1,
+            charge_states=[DefectChargeState(charge=-1, energy=0.5, degeneracy=1)],
+        )
+        factory = DefectSystemFactory(
+            defect_species=[frozen, donor, acceptor], dos=self.dos, volume=100
+        )
+        T_high, T_low = 1000, 300
+
+        high = factory.at(T_high).concentration_dict(per_volume=False)
+        low = factory.at(
+            T_low, fixed_concentrations={"X_frozen": high["X_frozen"]}
+        ).concentration_dict(per_volume=False)
+
+        # the frozen species keeps its high-temperature total
+        self.assertAlmostEqual(
+            low["X_frozen"], high["X_frozen"], delta=abs(high["X_frozen"]) * 1e-9
+        )
+        # a non-frozen species and the carriers re-equilibrate
+        self.assertNotAlmostEqual(low["D"], high["D"])
+        self.assertNotAlmostEqual(low["n0"], high["n0"])
+
+    def test_fix_on_one_call_does_not_leak_to_another_or_to_the_factory(self):
+        species = self._donor("X")
+        factory = DefectSystemFactory(
+            defect_species=[species], dos=self.dos, volume=100
+        )
+
+        fixed = factory.at(300, fixed_concentrations={"X": 0.01})
+        free = factory.at(300)
+
+        # the un-fixed call is unaffected by the earlier fixed call
+        self.assertIsNone(free.defect_species_by_name("X").fixed_concentration)
+        self.assertNotAlmostEqual(
+            free.concentration_dict(per_volume=False)["X"], 0.01
+        )
+        self.assertAlmostEqual(
+            fixed.concentration_dict(per_volume=False)["X"], 0.01
+        )
+        # the factory's own species object is never mutated
+        self.assertIsNone(species.fixed_concentration)
+
+    def test_fix_composes_with_formation_energy_corrections(self):
+        cs_a = DefectChargeState(charge=1, energy=0.5, degeneracy=1)
+        cs_b = DefectChargeState(charge=1, energy=0.9, degeneracy=1)
+        corrected = DefectSpecies("X_i", nsites=1, charge_states=[cs_a, cs_b])
+        acceptor = DefectSpecies(
+            name="A",
+            nsites=1,
+            charge_states=[DefectChargeState(charge=-1, energy=0.5, degeneracy=1)],
+        )
+        factory = DefectSystemFactory(
+            defect_species=[corrected, acceptor],
+            dos=self.dos,
+            volume=100,
+            formation_energy_correction_fns={
+                cs_a: lambda T: 0.1,
+                cs_b: lambda T: -0.05,
+            },
+        )
+        system = factory.at(300, fixed_concentrations={"X_i": 0.02})
+
+        # the corrections (resolved by identity) survive applying the fix
+        self.assertAlmostEqual(system.defect_species[0].charge_states[0].energy, 0.6)
+        self.assertAlmostEqual(system.defect_species[0].charge_states[1].energy, 0.85)
+        # and the fix (resolved by name) is in effect
+        self.assertAlmostEqual(
+            system.concentration_dict(per_volume=False)["X_i"], 0.02
+        )
+
+    def test_unknown_species_name_raises_value_error_naming_it(self):
+        with self.assertRaises(ValueError) as ctx:
+            DefectSystem(
+                defect_species=[self._donor("X")],
+                dos=self.dos,
+                volume=100,
+                temperature=300,
+                fixed_concentrations={"NOPE": 0.01},
+            )
+        self.assertIn("NOPE", str(ctx.exception))
+
+    def test_over_budget_fix_raises_value_error_at_construction(self):
+        with self.assertRaises(ValueError):
+            DefectSystem(
+                defect_species=[self._donor("X", nsites=1)],
+                dos=self.dos,
+                volume=100,
+                temperature=300,
+                fixed_concentrations={"X": 5.0},
+            )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`DefectSystem.__init__` now accepts `fixed_concentrations`, a `dict[str, float]`
mapping a species name to a fixed total concentration per unit cell. Each named
species has its total fixed at the given value on the constructor's own deep
copies of `defect_species`, overriding any species-level `fixed_concentration`
the species was constructed with.

The fix is applied by name to the copies, after the existing deep-copy and
formation-energy-correction steps and before `_validate_fixed_concentrations`.
Resolving by name on the copies keeps it independent of
`formation_energy_corrections`, which resolve by identity against the passed-in
objects: the two mechanisms compose without disturbing one another, and the
caller's species are never mutated. Unknown names raise a `ValueError` listing
the available species; an over-budget or inconsistent fix is rejected at
construction by the unchanged `_validate_fixed_concentrations` check running
over the now-fixed copies. `None` or an empty dict is a no-op.

`DefectSystemFactory.at` already forwards `**overrides` to the constructor, so
`factory.at(T, fixed_concentrations={...})` now works without any change to the
factory's logic; only its docstring is corrected. This makes the
anneal-and-quench workflow it documents work: freeze some species' totals at
their high-temperature values and re-solve at a lower temperature,
`factory.at(T_low, fixed_concentrations={n: high[n] for n in frozen})`.

Because the fix is a declarative constructor input applied to private copies
rather than a mutation of a shared `DefectSpecies`, it also fits the
construction-time, never-mutate-the-caller model already used for band-edge
shifts and formation-energy corrections.