### PR TITLE
Add high-occupancy DiluteLimitWarning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,12 +116,13 @@
   a lower temperature, e.g.
   `factory.at(T_low, fixed_concentrations={n: high[n] for n in frozen})`.
 - `DefectSystem` and `DefectSystemFactory` now emit a `DiluteLimitWarning`
-  (a dedicated `UserWarning` subclass) when a defect species' solved site
-  occupancy exceeds `occupancy_warning_threshold` (default 0.01, i.e. 1%; pass
-  `None` to disable, or a finite fraction in (0, 1] to retune). py-sc-fermi
-  models dilute, non-interacting defects, so a high occupancy flags a regime in
-  which un-modelled defect-defect interactions may make the results
-  non-physical. The threshold is a reporting preference and is not serialised.
+  (a dedicated `UserWarning` subclass), at most once per system, when a defect
+  species' solved site occupancy exceeds `occupancy_warning_threshold`
+  (default 0.01, i.e. 1%; pass `None` to disable, or a finite fraction in
+  (0, 1] to retune). py-sc-fermi models dilute, non-interacting defects, so a
+  high occupancy flags a regime in which un-modelled defect-defect interactions
+  may make the results non-physical. The threshold is a reporting preference
+  and is not serialised.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,13 @@
   freeze some species' totals at their high-temperature values and re-solve at
   a lower temperature, e.g.
   `factory.at(T_low, fixed_concentrations={n: high[n] for n in frozen})`.
+- `DefectSystem` and `DefectSystemFactory` now emit a `DiluteLimitWarning`
+  (a dedicated `UserWarning` subclass) when a defect species' solved site
+  occupancy exceeds `occupancy_warning_threshold` (default 0.01, i.e. 1%; pass
+  `None` to disable, or a finite fraction in (0, 1] to retune). py-sc-fermi
+  models dilute, non-interacting defects, so a high occupancy flags a regime in
+  which un-modelled defect-defect interactions may make the results
+  non-physical. The threshold is a reporting preference and is not serialised.
 
 ### Bug Fixes
 

--- a/py_sc_fermi/defect_species.py
+++ b/py_sc_fermi/defect_species.py
@@ -38,6 +38,10 @@ class DefectSpecies:
             raise ValueError(
                 f"DefectSpecies '{name}' must have at least one charge state."
             )
+        if nsites <= 0:
+            raise ValueError(
+                f"DefectSpecies '{name}' must have nsites > 0; got {nsites}."
+            )
         self._name = name
         self._nsites = nsites
         self._charge_states = charge_states

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -251,6 +251,7 @@ class DefectSystem:
         formation_energy_corrections: dict[DefectChargeState, float] | None = None,
         rigid_shift: bool = True,
         fixed_concentrations: dict[str, float] | None = None,
+        occupancy_warning_threshold: float | None = 0.01,
     ):
         self.volume = volume
         self.dos = dos
@@ -259,6 +260,9 @@ class DefectSystem:
         self.vbm_shift = vbm_shift
         self.cbm_shift = cbm_shift
         self.rigid_shift = rigid_shift
+        self.occupancy_warning_threshold = self._validate_occupancy_warning_threshold(
+            occupancy_warning_threshold
+        )
 
         self.defect_species = copy.deepcopy(defect_species)
         self._apply_formation_energy_corrections(
@@ -271,6 +275,29 @@ class DefectSystem:
         self._validate_pools()
         self._apply_fixed_concentrations(fixed_concentrations or {})
         self._validate_fixed_concentrations()
+
+    @staticmethod
+    def _validate_occupancy_warning_threshold(value: float | None) -> float | None:
+        """Validate the site-occupancy warning threshold.
+
+        Returns ``value`` unchanged if it is ``None`` (warning disabled) or a
+        finite fraction in ``(0, 1]``.
+
+        Raises:
+            ValueError: if ``value`` is not ``None`` and not a finite number in
+                ``(0, 1]``. Occupancy is a fraction that maxes at 1.0, so a
+                threshold outside this range -- including NaN or infinity --
+                could never sensibly fire (NaN would silently disable the
+                warning rather than raise).
+        """
+        if value is None:
+            return None
+        if not (0.0 < value <= 1.0):
+            raise ValueError(
+                "occupancy_warning_threshold must be a fraction in (0, 1] or "
+                f"None; got {value}"
+            )
+        return value
 
     def _apply_fixed_concentrations(
         self, fixed_concentrations: dict[str, float]

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import math
+import warnings
 from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -18,6 +19,19 @@ from py_sc_fermi.dos import DOS
 from py_sc_fermi.element_pools import ElementPoolError
 
 _kboltz = _physical_constants["Boltzmann constant in eV/K"][0]
+
+
+class DiluteLimitWarning(UserWarning):
+    """Warns that a defect's solved site occupancy is high enough that
+    py-sc-fermi's dilute, non-interacting-defect assumption may no longer hold,
+    so the results may be non-physical.
+
+    Emitted by :meth:`DefectSystem.get_sc_fermi` -- and therefore by every
+    results path that solves (``report``, ``concentration_dict``,
+    ``site_percentages``) -- when any species' occupancy exceeds
+    ``DefectSystem.occupancy_warning_threshold``. A dedicated ``UserWarning``
+    subclass so it can be filtered independently of other warnings.
+    """
 
 
 # Pools as accepted by the constructor: each species given as a DefectSpecies
@@ -993,7 +1007,72 @@ class DefectSystem:
         # window brackets a genuine root. The returned residual is a diagnostic
         # on that solution.
         residual = abs(self.q_tot(e_fermi))
+        self._warn_if_high_occupancy(e_fermi)
         return e_fermi, residual
+
+    def _warn_if_high_occupancy(self, e_fermi: float) -> None:
+        """Emit a single ``DiluteLimitWarning`` if any species' solved site
+        occupancy exceeds ``occupancy_warning_threshold``.
+
+        Does nothing when the threshold is ``None``. Otherwise computes the
+        per-species occupancy fractions at the converged ``e_fermi`` (one extra
+        ``_global_defect_concs`` evaluation) and, if any species is above the
+        threshold, warns once -- naming every offending species and its
+        occupancy, worst first. Repeated identical solves are de-duplicated by
+        the standard ``warnings`` machinery.
+
+        Args:
+            e_fermi (float): the self-consistent Fermi energy from
+              ``get_sc_fermi``.
+        """
+        threshold = self.occupancy_warning_threshold
+        if threshold is None:
+            return
+        fractions = self._site_occupancy_fractions(e_fermi)
+        offenders = sorted(
+            (
+                (name, fraction)
+                for name, fraction in fractions.items()
+                if fraction > threshold
+            ),
+            key=lambda item: item[1],
+            reverse=True,
+        )
+        if not offenders:
+            return
+        warnings.warn(
+            self._high_occupancy_message(offenders),
+            DiluteLimitWarning,
+            stacklevel=3,
+        )
+
+    @staticmethod
+    def _high_occupancy_message(offenders: list[tuple[str, float]]) -> str:
+        """Build the ``DiluteLimitWarning`` message for the offending species.
+
+        Args:
+            offenders: ``(name, occupancy fraction)`` pairs, ordered worst first.
+
+        Returns:
+            str: a two-sentence message reporting the occupancies, naming the
+            dilute assumption, and warning the results may be non-physical.
+        """
+        caveat = (
+            "py-sc-fermi assumes dilute, non-interacting defects, so results at "
+            "this occupancy may be non-physical."
+        )
+        if len(offenders) == 1:
+            name, fraction = offenders[0]
+            return (
+                f"'{name}' reaches {fraction * 100:.0f}% site occupancy at the "
+                f"self-consistent Fermi level. {caveat}"
+            )
+        listed = [f"'{name}' ({fraction * 100:.0f}%)" for name, fraction in offenders]
+        joined = f"{', '.join(listed[:-1])} and {listed[-1]}"
+        return (
+            f"{joined} reach high site occupancy at the self-consistent Fermi "
+            f"level. {caveat}"
+        )
 
     def total_defect_charge_contributions(self, e_fermi: float) -> tuple[float,float]:
         lhs = rhs = 0.0

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -1320,6 +1320,7 @@ class DefectSystemFactory:
             dict[DefectChargeState, Callable[[float], float]] | None
         ) = None,
         rigid_shift: bool = True,
+        occupancy_warning_threshold: float | None = 0.01,
     ):
         self.defect_species = defect_species
         self.dos = dos
@@ -1331,6 +1332,7 @@ class DefectSystemFactory:
         self.cbm_shift_fn = cbm_shift_fn
         self.formation_energy_correction_fns = formation_energy_correction_fns or {}
         self.rigid_shift = rigid_shift
+        self.occupancy_warning_threshold = occupancy_warning_threshold
 
     def at(self, temperature: float, **overrides: Any) -> DefectSystem:
         """Build a `DefectSystem` snapshot at `temperature`.
@@ -1376,6 +1378,7 @@ class DefectSystemFactory:
             cbm_shift=cbm_shift,
             formation_energy_corrections=formation_energy_corrections,
             rigid_shift=self.rigid_shift,
+            occupancy_warning_threshold=self.occupancy_warning_threshold,
         )
         kwargs.update(overrides)
         return DefectSystem(**kwargs)

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -1094,6 +1094,41 @@ class DefectSystem:
                 decomp_concs[str(ds.name)] = by_charge
             return {**run_stats, **decomp_concs}
 
+    def _site_occupancy_fractions(self, e_fermi: float) -> dict[str, float]:
+        """Return each ``DefectSpecies``' site occupancy as a fraction of the
+        sites available to it, at an already-solved Fermi level.
+
+        The concentrations are the same pool- and exclusion-aware values used
+        by ``report`` and ``concentration_dict`` (``_global_defect_concs`` at
+        ``e_fermi``). The denominator is the sites available to the species:
+        the pool's total site count for a species in a ``site_pools`` entry,
+        otherwise its own ``nsites``. This is the fractional form of
+        ``site_percentages`` (which scales it by 100); both draw on a single
+        solved ``e_fermi`` rather than re-solving, so the high-occupancy warning
+        and ``site_percentages`` share one source of truth.
+
+        Args:
+            e_fermi (float): a self-consistent Fermi energy, as returned by
+              ``get_sc_fermi``.
+
+        Returns:
+            dict[str, float]: mapping of ``DefectSpecies`` name to its site
+            occupancy as a fraction (0.0-1.0).
+        """
+        concs = self._global_defect_concs(e_fermi)
+        pool_sites = {
+            name: n_sites
+            for n_sites, members in self.site_pools.values()
+            for name in members
+        }
+        return {
+            str(ds.name): float(
+                sum(concs.get(cs, 0.0) for cs in ds.charge_states)
+                / pool_sites.get(ds.name, ds.nsites)
+            )
+            for ds in self.defect_species
+        }
+
     def site_percentages(self) -> dict[str, float]:
         """Return each ``DefectSpecies``' solved site occupancy as a
         percentage of the sites available to it.
@@ -1112,19 +1147,9 @@ class DefectSystem:
             occupancy as a percentage.
         """
         e_fermi = self.get_sc_fermi()[0]
-        concs = self._global_defect_concs(e_fermi)
-        pool_sites = {
-            name: n_sites
-            for n_sites, members in self.site_pools.values()
-            for name in members
-        }
         return {
-            str(ds.name): float(
-                sum(concs.get(cs, 0.0) for cs in ds.charge_states)
-                / pool_sites.get(ds.name, ds.nsites)
-                * 100
-            )
-            for ds in self.defect_species
+            name: fraction * 100
+            for name, fraction in self._site_occupancy_fractions(e_fermi).items()
         }
 
     def as_dict(self) -> dict:

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -231,14 +231,26 @@ class DefectSystem:
           -- its own `nsites`, or its shared `site_pools` size -- or below its
           individually-fixed charge states), is rejected at construction by the
           same checks as a species-level fix. Defaults to None (no fixes).
+        occupancy_warning_threshold (float | None, optional): the site-occupancy
+          fraction (0.01 = 1%) above which a ``DiluteLimitWarning`` is emitted
+          when the system is solved, naming any species whose solved occupancy
+          exceeds it. py-sc-fermi assumes dilute, non-interacting defects, so a
+          high occupancy flags a regime in which un-modelled defect-defect
+          interactions may make the results non-physical. The default is a
+          heuristic, provisional value that will be revisited; lower it where
+          interactions matter sooner (e.g. charged defects in low-dielectric
+          hosts), or set ``None`` to silence the warning. Must be ``None`` or a
+          finite fraction in (0, 1]. This is a reporting preference, not part of
+          the physical system, and is not serialised. Defaults to 0.01.
 
     Raises:
         ValueError: if two entries in `defect_species` share a name, a pool
           references a species not in `defect_species`, a pool lists a
           species more than once, a species appears in more than one site
           pool, `formation_energy_corrections` references a `DefectChargeState`
-          that is not part of `defect_species`, or `fixed_concentrations` names
-          a species not in `defect_species`.
+          that is not part of `defect_species`, `fixed_concentrations` names
+          a species not in `defect_species`, or `occupancy_warning_threshold`
+          is not ``None`` or a finite fraction in (0, 1].
 
     Note:
         `DefectSystem` is an immutable, fixed-temperature snapshot:
@@ -1304,6 +1316,10 @@ class DefectSystemFactory:
           be `DefectChargeState`s in `defect_species`. Defaults to None.
         rigid_shift (bool, optional): passed to every `DefectSystem` built by
           `at()`. Defaults to True.
+        occupancy_warning_threshold (float | None, optional): passed to every
+          `DefectSystem` built by `at()`, so a temperature sweep warns
+          consistently. See `DefectSystem` for its meaning and validation.
+          Defaults to 0.01.
     """
 
     def __init__(

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import math
+import sys
 import warnings
 from collections import Counter
 from collections.abc import Callable
@@ -29,8 +30,9 @@ class DiluteLimitWarning(UserWarning):
     Emitted by :meth:`DefectSystem.get_sc_fermi` -- and therefore by every
     results path that solves (``report``, ``concentration_dict``,
     ``site_percentages``) -- when any species' occupancy exceeds
-    ``DefectSystem.occupancy_warning_threshold``. A dedicated ``UserWarning``
-    subclass so it can be filtered independently of other warnings.
+    ``DefectSystem.occupancy_warning_threshold``, at most once per
+    ``DefectSystem`` instance. A dedicated ``UserWarning`` subclass so it can be
+    filtered independently of other warnings.
     """
 
 
@@ -289,6 +291,7 @@ class DefectSystem:
         self.occupancy_warning_threshold = self._validate_occupancy_warning_threshold(
             occupancy_warning_threshold
         )
+        self._occupancy_warning_emitted = False
 
         self.defect_species = copy.deepcopy(defect_species)
         self._apply_formation_energy_corrections(
@@ -313,8 +316,7 @@ class DefectSystem:
             ValueError: if ``value`` is not ``None`` and not a finite number in
                 ``(0, 1]``. Occupancy is a fraction that maxes at 1.0, so a
                 threshold outside this range -- including NaN or infinity --
-                could never sensibly fire (NaN would silently disable the
-                warning rather than raise).
+                could never sensibly fire.
         """
         if value is None:
             return None
@@ -382,7 +384,8 @@ class DefectSystem:
         Raises:
             ValueError: if two roster species share a name, a pool references
                 a species not in the roster, a pool lists a species more than
-                once, or a species appears in more than one site pool.
+                once, a species appears in more than one site pool, or a site
+                pool has a non-positive site count.
         """
         name_counts = Counter(ds.name for ds in self.defect_species)
         duplicates = sorted(name for name, count in name_counts.items() if count > 1)
@@ -394,7 +397,12 @@ class DefectSystem:
 
         roster = set(name_counts)
         site_pool_of: dict[str, str] = {}
-        for pool_name, (_, members) in self.site_pools.items():
+        for pool_name, (n_pool_sites, members) in self.site_pools.items():
+            if not (n_pool_sites > 0):
+                raise ValueError(
+                    f"site pool '{pool_name}' must have n_sites > 0; "
+                    f"got {n_pool_sites}."
+                )
             self._check_pool_members("site pool", pool_name, members, roster)
             for name in members:
                 first = site_pool_of.setdefault(name, pool_name)
@@ -1023,22 +1031,26 @@ class DefectSystem:
         return e_fermi, residual
 
     def _warn_if_high_occupancy(self, e_fermi: float) -> None:
-        """Emit a single ``DiluteLimitWarning`` if any species' solved site
-        occupancy exceeds ``occupancy_warning_threshold``.
+        """Emit a ``DiluteLimitWarning`` if any species' solved site occupancy
+        exceeds ``occupancy_warning_threshold``.
 
-        Does nothing when the threshold is ``None``. Otherwise computes the
-        per-species occupancy fractions at the converged ``e_fermi`` (one extra
-        ``_global_defect_concs`` evaluation) and, if any species is above the
-        threshold, warns once -- naming every offending species and its
-        occupancy, worst first. Repeated identical solves are de-duplicated by
-        the standard ``warnings`` machinery.
+        Does nothing when the threshold is ``None`` or when this system has
+        already warned. Otherwise computes the per-species occupancy fractions
+        at the converged ``e_fermi`` and, if any species is above the threshold,
+        emits one warning naming every offending species and its occupancy,
+        worst first. The warning fires at most once per ``DefectSystem``: the
+        occupancy verdict is deterministic for an immutable snapshot, so a user
+        inspecting one solved system through several methods (``report``,
+        ``concentration_dict``, ``site_percentages``, a direct ``get_sc_fermi``)
+        sees a single warning, attributed to their own call rather than to an
+        internal solve method.
 
         Args:
             e_fermi (float): the self-consistent Fermi energy from
               ``get_sc_fermi``.
         """
         threshold = self.occupancy_warning_threshold
-        if threshold is None:
+        if self._occupancy_warning_emitted or threshold is None:
             return
         fractions = self._site_occupancy_fractions(e_fermi)
         offenders = sorted(
@@ -1052,11 +1064,32 @@ class DefectSystem:
         )
         if not offenders:
             return
+        self._occupancy_warning_emitted = True
         warnings.warn(
             self._high_occupancy_message(offenders),
             DiluteLimitWarning,
-            stacklevel=3,
+            stacklevel=self._warning_stacklevel(),
         )
+
+    @staticmethod
+    def _warning_stacklevel() -> int:
+        """``stacklevel`` for the high-occupancy ``warnings.warn`` call that
+        points at the first frame outside this module.
+
+        The warning is reached at different stack depths -- directly via
+        ``get_sc_fermi``, or one frame deeper via ``report``,
+        ``concentration_dict`` or ``site_percentages`` -- so no fixed
+        ``stacklevel`` blames the caller on every path. Counting frames up to
+        the first one outside ``py_sc_fermi.defect_system`` attributes the
+        warning to the user's call. ``warnings.warn`` is invoked one frame above
+        this helper, where the count begins.
+        """
+        frame: Any = sys._getframe(1)
+        level = 1
+        while frame is not None and frame.f_globals.get("__name__") == __name__:
+            frame = frame.f_back
+            level += 1
+        return level
 
     @staticmethod
     def _high_occupancy_message(offenders: list[tuple[str, float]]) -> str:
@@ -1076,10 +1109,10 @@ class DefectSystem:
         if len(offenders) == 1:
             name, fraction = offenders[0]
             return (
-                f"'{name}' reaches {fraction * 100:.0f}% site occupancy at the "
+                f"'{name}' reaches {fraction * 100:.3g}% site occupancy at the "
                 f"self-consistent Fermi level. {caveat}"
             )
-        listed = [f"'{name}' ({fraction * 100:.0f}%)" for name, fraction in offenders]
+        listed = [f"'{name}' ({fraction * 100:.3g}%)" for name, fraction in offenders]
         joined = f"{', '.join(listed[:-1])} and {listed[-1]}"
         return (
             f"{joined} reach high site occupancy at the self-consistent Fermi "

--- a/tests/test_defect_species.py
+++ b/tests/test_defect_species.py
@@ -54,6 +54,14 @@ class TestDefectSpeciesInit(unittest.TestCase):
             DefectSpecies(name="V_O", nsites=2, charge_states=[])
         self.assertIn("V_O", str(cm.exception))
 
+    def test_defect_species_raises_with_non_positive_nsites(self):
+        cs = Mock(spec=DefectChargeState)
+        cs.charge = 0
+        for bad in (0, -1):
+            with self.assertRaises(ValueError) as cm:
+                DefectSpecies(name="V_O", nsites=bad, charge_states=[cs])
+            self.assertIn("V_O", str(cm.exception))
+
 
 class TestDefectSpecies(unittest.TestCase):
     def setUp(self):

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -2531,6 +2531,31 @@ class TestDiluteLimitWarning(unittest.TestCase):
         self.assertIn("dilute", message.lower())
         self.assertIn("non-physical", message.lower())
 
+    def test_pooled_species_occupancy_measured_against_pool_size(self):
+        # nsites=1 but the species shares a 10-site pool. At ~0.057 eV it holds
+        # ~1 defect/cell -> ~10% of the POOL. If occupancy were (wrongly)
+        # measured against nsites=1 it would read ~100%, so the reported figure
+        # discriminates the denominator. site_percentages is the pool-based
+        # reference the warning must agree with.
+        species = DefectSpecies(
+            "P",
+            nsites=1,
+            charge_states=[DefectChargeState(charge=0, energy=0.057, degeneracy=1)],
+        )
+        system = self._make_system(
+            [species],
+            site_pools={"shared": (10.0, [species])},
+            occupancy_warning_threshold=0.01,
+        )
+        with warnings.catch_warnings(record=True) as records:
+            warnings.simplefilter("always")
+            system.get_sc_fermi()
+        dilute = self._dilute_warnings(records)
+        self.assertEqual(len(dilute), 1)
+        pool_pct = system.site_percentages()["P"]
+        self.assertLess(pool_pct, 100.0)
+        self.assertIn(f"{pool_pct:.0f}%", str(dilute[0].message))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -2,6 +2,7 @@ import json
 import os
 import unittest
 import warnings
+from contextlib import redirect_stdout
 from io import StringIO
 from unittest.mock import Mock, patch
 
@@ -2503,19 +2504,31 @@ class TestDiluteLimitWarning(unittest.TestCase):
         self.assertEqual(len(self._dilute_warnings(fires_records)), 1)
         self.assertEqual(self._dilute_warnings(silent_records), [])
 
-    def test_multiple_high_occupancy_species_listed_in_one_warning(self):
-        a = self._saturating_species("A", energy=-2.0)
-        b = self._saturating_species("B", energy=-1.5)
-        system = self._make_system([a, b])
+    def test_multiple_high_occupancy_species_listed_worst_first(self):
+        # Distinct occupancies (neutral states are e_fermi-independent): the
+        # lower-occupancy species is declared FIRST, so the test fails if the
+        # message is not re-ordered worst-first.
+        low = DefectSpecies(
+            "low_occ",
+            nsites=1,
+            charge_states=[DefectChargeState(charge=0, energy=0.1, degeneracy=1)],
+        )
+        high = DefectSpecies(
+            "high_occ",
+            nsites=1,
+            charge_states=[DefectChargeState(charge=0, energy=0.0, degeneracy=1)],
+        )
+        system = self._make_system([low, high])
         with warnings.catch_warnings(record=True) as records:
             warnings.simplefilter("always")
             system.get_sc_fermi()
         dilute = self._dilute_warnings(records)
         self.assertEqual(len(dilute), 1)
         message = str(dilute[0].message)
-        self.assertIn("A", message)
-        self.assertIn("B", message)
+        self.assertIn("low_occ", message)
+        self.assertIn("high_occ", message)
         self.assertIn(" and ", message)
+        self.assertLess(message.index("high_occ"), message.index("low_occ"))
 
     def test_warning_is_dilute_limit_category_with_expected_content(self):
         system = self._make_system([self._saturating_species("S")])
@@ -2577,7 +2590,34 @@ class TestDiluteLimitWarning(unittest.TestCase):
         self.assertEqual(len(dilute), 1)
         pool_pct = system.site_percentages()["P"]
         self.assertLess(pool_pct, 100.0)
-        self.assertIn(f"{pool_pct:.0f}%", str(dilute[0].message))
+        self.assertIn(f"{pool_pct:.3g}%", str(dilute[0].message))
+
+    def test_warns_at_most_once_per_system_under_default_filter(self):
+        # Inspecting one solved system several ways reaches the chokepoint at
+        # different stack depths; under the realistic default filter (not
+        # "always") that would defeat location-based de-duplication, so the
+        # once-per-instance guard is what holds this to a single warning.
+        system = self._make_system([self._saturating_species("S")])
+        with warnings.catch_warnings(record=True) as records, redirect_stdout(
+            StringIO()
+        ):
+            warnings.simplefilter("default")
+            system.report()
+            system.site_percentages()
+            system.concentration_dict()
+            system.get_sc_fermi()
+        self.assertEqual(len(self._dilute_warnings(records)), 1)
+
+    def test_threshold_absent_from_as_dict(self):
+        system = self._make_system(
+            [self._saturating_species("S")], occupancy_warning_threshold=0.5
+        )
+        self.assertNotIn("occupancy_warning_threshold", system.as_dict())
+
+    def test_zero_site_pool_rejected_at_construction(self):
+        species = self._saturating_species("S")
+        with self.assertRaises(ValueError):
+            self._make_system([species], site_pools={"shared": (0.0, [species])})
 
 
 if __name__ == "__main__":

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -2531,6 +2531,29 @@ class TestDiluteLimitWarning(unittest.TestCase):
         self.assertIn("dilute", message.lower())
         self.assertIn("non-physical", message.lower())
 
+    def test_factory_forwards_threshold_to_built_systems(self):
+        species = self._saturating_species("S")
+        warning_factory = DefectSystemFactory(
+            defect_species=[species],
+            dos=self.dos,
+            volume=100,
+            occupancy_warning_threshold=0.01,
+        )
+        silent_factory = DefectSystemFactory(
+            defect_species=[species],
+            dos=self.dos,
+            volume=100,
+            occupancy_warning_threshold=None,
+        )
+        with warnings.catch_warnings(record=True) as warn_records:
+            warnings.simplefilter("always")
+            warning_factory.at(300).get_sc_fermi()
+        with warnings.catch_warnings(record=True) as silent_records:
+            warnings.simplefilter("always")
+            silent_factory.at(300).get_sc_fermi()
+        self.assertEqual(len(self._dilute_warnings(warn_records)), 1)
+        self.assertEqual(self._dilute_warnings(silent_records), [])
+
     def test_pooled_species_occupancy_measured_against_pool_size(self):
         # nsites=1 but the species shares a 10-site pool. At ~0.057 eV it holds
         # ~1 defect/cell -> ~10% of the POOL. If occupancy were (wrongly)

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -2362,5 +2362,62 @@ class TestDefectSystemFixedConcentrations(unittest.TestCase):
             )
 
 
+class TestDiluteLimitWarning(unittest.TestCase):
+    def setUp(self):
+        self.dos = DOS(
+            dos=np.ones(101),
+            edos=np.linspace(-5.0, 5.0, 101),
+            bandgap=2.0,
+            nelect=10,
+        )
+
+    def _make_system(self, defect_species, **kwargs):
+        return DefectSystem(
+            defect_species=defect_species,
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+            **kwargs,
+        )
+
+    @staticmethod
+    def _saturating_species(name="S", nsites=2, energy=-2.0):
+        # A neutral state's occupancy w/(1+w) is e_fermi-independent; a low
+        # energy drives it to ~100% of its sites.
+        return DefectSpecies(
+            name,
+            nsites=nsites,
+            charge_states=[DefectChargeState(charge=0, energy=energy, degeneracy=1)],
+        )
+
+    def test_threshold_defaults_to_one_percent(self):
+        system = self._make_system([self._saturating_species()])
+        self.assertEqual(system.occupancy_warning_threshold, 0.01)
+
+    def test_threshold_is_stored(self):
+        system = self._make_system(
+            [self._saturating_species()], occupancy_warning_threshold=0.2
+        )
+        self.assertEqual(system.occupancy_warning_threshold, 0.2)
+
+    def test_none_threshold_is_stored(self):
+        system = self._make_system(
+            [self._saturating_species()], occupancy_warning_threshold=None
+        )
+        self.assertIsNone(system.occupancy_warning_threshold)
+
+    def test_out_of_range_threshold_raises(self):
+        species = self._saturating_species()
+        for bad in (0.0, 1.5, -0.1, float("nan"), float("inf")):
+            with self.assertRaises(ValueError):
+                self._make_system([species], occupancy_warning_threshold=bad)
+
+    def test_threshold_of_one_is_allowed(self):
+        system = self._make_system(
+            [self._saturating_species()], occupancy_warning_threshold=1.0
+        )
+        self.assertEqual(system.occupancy_warning_threshold, 1.0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -2418,6 +2418,26 @@ class TestDiluteLimitWarning(unittest.TestCase):
         )
         self.assertEqual(system.occupancy_warning_threshold, 1.0)
 
+    def test_site_occupancy_fractions_match_site_percentages(self):
+        # Pooled system: occupancy is measured against the pool size, and the
+        # fractions are exactly site_percentages / 100.
+        a = DefectSpecies(
+            "A",
+            nsites=5,
+            charge_states=[DefectChargeState(charge=0, energy=0.057, degeneracy=1)],
+        )
+        b = DefectSpecies(
+            "B",
+            nsites=1,
+            charge_states=[DefectChargeState(charge=0, energy=0.2, degeneracy=1)],
+        )
+        system = self._make_system([a, b], site_pools={"shared": (4.0, [a, b])})
+        e_fermi = system.get_sc_fermi()[0]
+        fractions = system._site_occupancy_fractions(e_fermi)
+        percentages = system.site_percentages()
+        for name in ("A", "B"):
+            self.assertAlmostEqual(fractions[name] * 100, percentages[name], places=10)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -1,6 +1,7 @@
 import json
 import os
 import unittest
+import warnings
 from io import StringIO
 from unittest.mock import Mock, patch
 
@@ -10,7 +11,11 @@ from scipy.constants import physical_constants
 
 from py_sc_fermi.defect_charge_state import DefectChargeState
 from py_sc_fermi.defect_species import DefectSpecies
-from py_sc_fermi.defect_system import DefectSystem, DefectSystemFactory
+from py_sc_fermi.defect_system import (
+    DefectSystem,
+    DefectSystemFactory,
+    DiluteLimitWarning,
+)
 from py_sc_fermi.dos import DOS
 from py_sc_fermi.element_pools import ElementPoolError
 
@@ -2437,6 +2442,94 @@ class TestDiluteLimitWarning(unittest.TestCase):
         percentages = system.site_percentages()
         for name in ("A", "B"):
             self.assertAlmostEqual(fractions[name] * 100, percentages[name], places=10)
+
+    @staticmethod
+    def _dilute_warnings(records):
+        return [r for r in records if issubclass(r.category, DiluteLimitWarning)]
+
+    def test_high_occupancy_species_emits_single_warning(self):
+        system = self._make_system([self._saturating_species("S")])
+        with warnings.catch_warnings(record=True) as records:
+            warnings.simplefilter("always")
+            system.get_sc_fermi()
+        dilute = self._dilute_warnings(records)
+        self.assertEqual(len(dilute), 1)
+        self.assertIn("S", str(dilute[0].message))
+
+    def test_dilute_species_emits_no_warning(self):
+        species = DefectSpecies(
+            "D",
+            nsites=1,
+            charge_states=[DefectChargeState(charge=0, energy=1.0, degeneracy=1)],
+        )
+        system = self._make_system([species])
+        with warnings.catch_warnings(record=True) as records:
+            warnings.simplefilter("always")
+            system.get_sc_fermi()
+        self.assertEqual(self._dilute_warnings(records), [])
+
+    def test_none_threshold_suppresses_warning(self):
+        system = self._make_system(
+            [self._saturating_species("S")], occupancy_warning_threshold=None
+        )
+        with warnings.catch_warnings(record=True) as records:
+            warnings.simplefilter("always")
+            system.get_sc_fermi()
+        self.assertEqual(self._dilute_warnings(records), [])
+
+    def test_custom_threshold_changes_when_warning_fires(self):
+        # Neutral state at ~0.057 eV -> ~10% site occupancy.
+        def at_ten_percent():
+            return DefectSpecies(
+                "T",
+                nsites=1,
+                charge_states=[
+                    DefectChargeState(charge=0, energy=0.057, degeneracy=1)
+                ],
+            )
+
+        fires = self._make_system(
+            [at_ten_percent()], occupancy_warning_threshold=0.01
+        )
+        silent = self._make_system(
+            [at_ten_percent()], occupancy_warning_threshold=0.5
+        )
+        with warnings.catch_warnings(record=True) as fires_records:
+            warnings.simplefilter("always")
+            fires.get_sc_fermi()
+        with warnings.catch_warnings(record=True) as silent_records:
+            warnings.simplefilter("always")
+            silent.get_sc_fermi()
+        self.assertEqual(len(self._dilute_warnings(fires_records)), 1)
+        self.assertEqual(self._dilute_warnings(silent_records), [])
+
+    def test_multiple_high_occupancy_species_listed_in_one_warning(self):
+        a = self._saturating_species("A", energy=-2.0)
+        b = self._saturating_species("B", energy=-1.5)
+        system = self._make_system([a, b])
+        with warnings.catch_warnings(record=True) as records:
+            warnings.simplefilter("always")
+            system.get_sc_fermi()
+        dilute = self._dilute_warnings(records)
+        self.assertEqual(len(dilute), 1)
+        message = str(dilute[0].message)
+        self.assertIn("A", message)
+        self.assertIn("B", message)
+        self.assertIn(" and ", message)
+
+    def test_warning_is_dilute_limit_category_with_expected_content(self):
+        system = self._make_system([self._saturating_species("S")])
+        with warnings.catch_warnings(record=True) as records:
+            warnings.simplefilter("always")
+            system.get_sc_fermi()
+        dilute = self._dilute_warnings(records)
+        self.assertEqual(len(dilute), 1)
+        self.assertIs(dilute[0].category, DiluteLimitWarning)
+        message = str(dilute[0].message)
+        self.assertIn("S", message)
+        self.assertIn("%", message)
+        self.assertIn("dilute", message.lower())
+        self.assertIn("non-physical", message.lower())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

py-sc-fermi is a dilute, non-interacting defect model. Now that site exclusion caps a species' occupancy at 100% (rather than producing the old, obviously-wrong >100% concentrations), a user can silently end up in a high-occupancy regime where the un-modelled defect-defect interactions (binding, association, clustering, strain) are significant. This adds a terse runtime flag for that regime.

- New `DiluteLimitWarning` (a dedicated `UserWarning` subclass, so it can be filtered independently) emitted when a defect species' solved site occupancy exceeds a configurable threshold. The message reports the occupancy, names the dilute assumption, and warns the result may be non-physical -- it deliberately does not explain the model or point elsewhere.
- `DefectSystem` and `DefectSystemFactory` gain `occupancy_warning_threshold` (a site-occupancy fraction; default 0.01, i.e. 1%; `None` disables). It is validated to `None` or a finite fraction in (0, 1]. The default is a heuristic, provisional value that will be revisited; it can be lowered where interactions matter sooner (e.g. charged defects in low-dielectric hosts).
- Occupancy is computed once via a shared `_site_occupancy_fractions` helper factored out of `site_percentages`, so the warning and the reporting paths agree on the same pool-aware denominators (a species' own `nsites`, or its `site_pools` size when pooled) without re-solving. `site_percentages` is now that helper scaled by 100.
- The warning is emitted at the single solve chokepoint `get_sc_fermi`, after the self-consistent Fermi level is found, so `report`, `concentration_dict`, and `site_percentages` all inherit it. One combined warning per solve names every offending species and its occupancy (worst first); repeated identical solves rely on the standard `warnings` de-duplication.

The threshold is a reporting preference, not part of the physical system, and is intentionally not serialised (absent from `as_dict`/`from_dict`). Chemical-potential reporting and the element-pool solver are untouched.

Changelog updated under V3.0.0.