### PR TITLE
Surface solved element chemical-potential shifts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,16 @@
   high occupancy flags a regime in which un-modelled defect-defect interactions
   may make the results non-physical. The threshold is a reporting preference
   and is not serialised.
+- Added `DefectSystem.element_chemical_potential_shifts`, which reports the
+  solved chemical-potential shift (`delta_mu`, in eV) of each element
+  constrained by `element_pools`, evaluated at the self-consistent Fermi
+  level and relative to the reference at which the formation energies were
+  defined. A target above an element's unconstrained content gives a positive
+  shift, below it a negative shift, and equal to it a near-zero shift. The
+  shift is re-derived from the same element-pool solve used for the
+  concentrations, so it is consistent with `concentration_dict`; an element
+  driven to the complete-exclusion limit is reported as `-inf`. Intended for
+  external stability-region checks (py-sc-fermi has no competing-phase data).
 
 ### Bug Fixes
 

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -1276,6 +1276,57 @@ class DefectSystem:
             for name, fraction in self._site_occupancy_fractions(e_fermi).items()
         }
 
+    def element_chemical_potential_shifts(self) -> dict[str, float]:
+        """Solved chemical-potential shifts for each constrained element.
+
+        Returns the chemical-potential shift ``delta_mu`` (in eV) of every
+        element constrained by ``element_pools``, evaluated at the
+        self-consistent Fermi level. ``delta_mu`` is measured relative to the
+        chemical-potential reference at which the formation energies were
+        defined: a target above the element's unconstrained content gives
+        ``delta_mu > 0``, a target below it ``delta_mu < 0``, and a target
+        equal to it ``delta_mu ~ 0``. These are shifts, not absolute chemical
+        potentials.
+
+        py-sc-fermi reports the shift but cannot judge whether it is
+        physically accessible, having no competing-phase data. The value is
+        intended for an external stability-region check: a shift inside the
+        host's stability region corresponds to an accessible concentration,
+        one outside to a supersaturated or otherwise unphysical state.
+
+        The shift is re-derived from the same deterministic element-pool solve
+        used for the concentrations at this Fermi level, so it is consistent
+        with ``concentration_dict``.
+
+        Returns:
+            dict[str, float]: each constrained element mapped to its
+            ``delta_mu`` in eV, in the order the pools were declared. Empty
+            when no ``element_pools`` are defined. An element whose target is
+            met with zero variable content and that has no content-removing
+            (negative-stoichiometry) state is fully excluded; its shift is the
+            ``delta_mu -> -inf`` limit, reported as ``-math.inf``.
+
+        Raises:
+            ElementPoolError: if the element-pool constraints are infeasible
+                at the self-consistent Fermi level (raised by
+                ``get_sc_fermi``).
+        """
+        if not self.element_pools:
+            return {}
+        e_fermi = self.get_sc_fermi()[0]
+        groups, _ = self._build_exclusion_groups(e_fermi)
+        pools = self._resolve_element_pools()
+        elements = list(pools)
+        stoich = self._stoichiometry_lookup(pools)
+        mu, solved_elements, _ = self._solve_element_pools(
+            groups, pools, elements, stoich
+        )
+        shifts = {
+            elem: float(mu[i] * _kboltz * self.temperature)
+            for i, elem in enumerate(solved_elements)
+        }
+        return {elem: shifts.get(elem, -math.inf) for elem in pools}
+
     def as_dict(self) -> dict:
         """Return a dictionary representation of the ``DefectSystem``.
 

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -1307,9 +1307,9 @@ class DefectSystem:
             ``delta_mu -> -inf`` limit, reported as ``-math.inf``.
 
         Raises:
-            ElementPoolError: if the element-pool constraints are infeasible
-                at the self-consistent Fermi level (raised by
-                ``get_sc_fermi``).
+            ElementPoolError: if the element-pool constraints cannot be
+                satisfied -- the targets are mutually inconsistent or exceed
+                the available sites.
         """
         if not self.element_pools:
             return {}

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -1242,6 +1242,26 @@ class TestDefectSystemElementPools(unittest.TestCase):
         self.assertTrue(math.isfinite(shifts["A"]))
         self.assertTrue(math.isfinite(shifts["C"]))
 
+    def test_unachievable_target_raises(self):
+        # A target above the site-exclusion ceiling cannot be met at any
+        # chemical potential; the solver rejects it and the surfaced
+        # ElementPoolError propagates out of element_chemical_potential_shifts.
+        sp = DefectSpecies(
+            "S",
+            nsites=2,
+            charge_states=[DefectChargeState(charge=0, energy=1.0, degeneracy=1)],
+        )
+        system = DefectSystem(
+            defect_species=[sp],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+            element_pools={"X": (5.0, [("S", 1.0)])},
+            occupancy_warning_threshold=None,
+        )
+        with self.assertRaises(ElementPoolError):
+            system.element_chemical_potential_shifts()
+
 
 class TestDefectSystemElementPoolConvergence(unittest.TestCase):
     """Convergence of the element-pool chemical-potential solve across

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -1117,33 +1117,37 @@ class TestDefectSystemElementPools(unittest.TestCase):
         self.assertGreater(above.element_chemical_potential_shifts()["X"], 0.0)
         self.assertLess(below.element_chemical_potential_shifts()["X"], 0.0)
 
-    def test_chemical_potential_shift_is_dimensionless_mu_times_kt(self):
+    def test_shift_reproduces_concentration_dict_content(self):
+        # Convert the reported delta_mu back to the activity
+        # lambda = exp(delta_mu / kT) and feed it through the site-exclusion
+        # formula: it must reproduce the species content concentration_dict
+        # reports at the same solved Fermi level. An independent check of the
+        # eV magnitude and of the documented consistency with
+        # concentration_dict.
+        nsites, energy, degeneracy, target, temperature = 10, 1.0, 1, 1e-3, 300
         sp = DefectSpecies(
             "S",
-            nsites=10,
-            charge_states=[DefectChargeState(charge=0, energy=1.0, degeneracy=1)],
+            nsites=nsites,
+            charge_states=[
+                DefectChargeState(charge=0, energy=energy, degeneracy=degeneracy)
+            ],
         )
         system = DefectSystem(
             defect_species=[sp],
             dos=self.dos,
             volume=100,
-            temperature=300,
-            element_pools={"X": (1e-3, [("S", 1.0)])},
+            temperature=temperature,
+            element_pools={"X": (target, [("S", 1.0)])},
             occupancy_warning_threshold=None,
         )
-        e_fermi = system.get_sc_fermi()[0]
-        groups, _ = system._build_exclusion_groups(e_fermi)
-        pools = system._resolve_element_pools()
-        elements = list(pools)
-        stoich = system._stoichiometry_lookup(pools)
-        mu, solved_elements, _ = system._solve_element_pools(
-            groups, pools, elements, stoich
-        )
-        expected = float(mu[solved_elements.index("X")] * kboltz * 300)
+        delta_mu = system.element_chemical_potential_shifts()["X"]
+        w = degeneracy * math.exp(-energy / (kboltz * temperature))
+        activity = w * math.exp(delta_mu / (kboltz * temperature))
+        content_from_shift = nsites * activity / (1 + activity)
 
-        self.assertEqual(
-            system.element_chemical_potential_shifts()["X"], expected
-        )
+        content_from_dict = system.concentration_dict(per_volume=False)["S"]
+        self.assertAlmostEqual(content_from_shift, content_from_dict, places=10)
+        self.assertAlmostEqual(content_from_dict, target, places=6)
 
     def test_no_element_pools_returns_empty_dict(self):
         system = DefectSystem(
@@ -1206,6 +1210,37 @@ class TestDefectSystemElementPools(unittest.TestCase):
         self.assertEqual(
             system.element_chemical_potential_shifts()["X"], -math.inf
         )
+
+    def test_excluded_element_keeps_declaration_order(self):
+        # A middle pool driven to exclusion (-inf) must keep its declared
+        # position: the dict is keyed by declaration order, not by the solver's
+        # narrowed element list, which drops excluded elements.
+        def neutral(name):
+            return DefectSpecies(
+                name,
+                nsites=10,
+                charge_states=[
+                    DefectChargeState(charge=0, energy=1.0, degeneracy=1)
+                ],
+            )
+
+        system = DefectSystem(
+            defect_species=[neutral("Sa"), neutral("Sb"), neutral("Sc")],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+            element_pools={
+                "A": (1e-3, [("Sa", 1.0)]),
+                "B": (0.0, [("Sb", 1.0)]),
+                "C": (2e-3, [("Sc", 1.0)]),
+            },
+            occupancy_warning_threshold=None,
+        )
+        shifts = system.element_chemical_potential_shifts()
+        self.assertEqual(list(shifts), ["A", "B", "C"])
+        self.assertEqual(shifts["B"], -math.inf)
+        self.assertTrue(math.isfinite(shifts["A"]))
+        self.assertTrue(math.isfinite(shifts["C"]))
 
 
 class TestDefectSystemElementPoolConvergence(unittest.TestCase):

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -1,4 +1,5 @@
 import json
+import math
 import os
 import unittest
 import warnings
@@ -1081,6 +1082,130 @@ class TestDefectSystemElementPools(unittest.TestCase):
             system._global_defect_concs(1.0)
         self.assertIn("X", str(ctx.exception))
         self.assertIn("Y", str(ctx.exception))
+
+    def test_chemical_potential_shift_sign_tracks_target_vs_unconstrained(self):
+        # A charge-neutral species does not enter charge neutrality, so the
+        # pooled and unpooled systems share the same self-consistent e_fermi;
+        # at target == unconstrained content the solver needs no shift.
+        def build(**kwargs):
+            sp = DefectSpecies(
+                "S",
+                nsites=10,
+                charge_states=[DefectChargeState(charge=0, energy=1.0, degeneracy=1)],
+            )
+            return DefectSystem(
+                defect_species=[sp],
+                dos=self.dos,
+                volume=100,
+                temperature=300,
+                occupancy_warning_threshold=None,
+                **kwargs,
+            )
+
+        base = build()
+        e_fermi = base.get_sc_fermi()[0]
+        concs = base._global_defect_concs(e_fermi)
+        c0 = sum(concs[cs] for cs in base.defect_species[0].charge_states)
+
+        at_target = build(element_pools={"X": (c0, [("S", 1.0)])})
+        above = build(element_pools={"X": (2 * c0, [("S", 1.0)])})
+        below = build(element_pools={"X": (0.5 * c0, [("S", 1.0)])})
+
+        self.assertAlmostEqual(
+            at_target.element_chemical_potential_shifts()["X"], 0.0, places=6
+        )
+        self.assertGreater(above.element_chemical_potential_shifts()["X"], 0.0)
+        self.assertLess(below.element_chemical_potential_shifts()["X"], 0.0)
+
+    def test_chemical_potential_shift_is_dimensionless_mu_times_kt(self):
+        sp = DefectSpecies(
+            "S",
+            nsites=10,
+            charge_states=[DefectChargeState(charge=0, energy=1.0, degeneracy=1)],
+        )
+        system = DefectSystem(
+            defect_species=[sp],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+            element_pools={"X": (1e-3, [("S", 1.0)])},
+            occupancy_warning_threshold=None,
+        )
+        e_fermi = system.get_sc_fermi()[0]
+        groups, _ = system._build_exclusion_groups(e_fermi)
+        pools = system._resolve_element_pools()
+        elements = list(pools)
+        stoich = system._stoichiometry_lookup(pools)
+        mu, solved_elements, _ = system._solve_element_pools(
+            groups, pools, elements, stoich
+        )
+        expected = float(mu[solved_elements.index("X")] * kboltz * 300)
+
+        self.assertEqual(
+            system.element_chemical_potential_shifts()["X"], expected
+        )
+
+    def test_no_element_pools_returns_empty_dict(self):
+        system = DefectSystem(
+            defect_species=[self.species],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+            occupancy_warning_threshold=None,
+        )
+        self.assertEqual(system.element_chemical_potential_shifts(), {})
+
+    def test_coupled_element_pools_report_finite_shifts(self):
+        sp_mgo = DefectSpecies(
+            "Mg_O",
+            nsites=20,
+            charge_states=[DefectChargeState(charge=0, energy=0.0, degeneracy=1)],
+        )
+        sp_mgi = DefectSpecies(
+            "Mg_i",
+            nsites=20,
+            charge_states=[DefectChargeState(charge=0, energy=0.0, degeneracy=1)],
+        )
+        sp_oi = DefectSpecies(
+            "O_i",
+            nsites=20,
+            charge_states=[DefectChargeState(charge=0, energy=0.0, degeneracy=1)],
+        )
+        system = DefectSystem(
+            defect_species=[sp_mgo, sp_mgi, sp_oi],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+            element_pools={
+                "Mg": (8.0, [("Mg_O", 1.0), ("Mg_i", 1.0)]),
+                "O": (5.0, [("Mg_O", 1.0), ("O_i", 1.0)]),
+            },
+            occupancy_warning_threshold=None,
+        )
+        shifts = system.element_chemical_potential_shifts()
+        self.assertEqual(set(shifts), {"Mg", "O"})
+        self.assertTrue(np.isfinite(shifts["Mg"]))
+        self.assertTrue(np.isfinite(shifts["O"]))
+
+    def test_fully_excluded_element_reports_negative_infinity(self):
+        # target 0 with a source-only species: the element is driven to the
+        # delta_mu -> -inf (complete-exclusion) limit and drops out of the solve.
+        sp = DefectSpecies(
+            "S",
+            nsites=10,
+            charge_states=[DefectChargeState(charge=0, energy=1.0, degeneracy=1)],
+        )
+        system = DefectSystem(
+            defect_species=[sp],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+            element_pools={"X": (0.0, [("S", 1.0)])},
+            occupancy_warning_threshold=None,
+        )
+        self.assertEqual(
+            system.element_chemical_potential_shifts()["X"], -math.inf
+        )
 
 
 class TestDefectSystemElementPoolConvergence(unittest.TestCase):


### PR DESCRIPTION
## Summary

Adds a read-only public method `DefectSystem.element_chemical_potential_shifts()` that surfaces the per-element chemical-potential shift the element-pool solver already computes and then discards.

When `element_pools` constrain an element's total content to a target, the solver finds the element chemical potential that delivers that content (inside `_global_defect_concs`, via `_solve_element_pools`). This method re-runs that deterministic solve at the self-consistent Fermi level and reports the result, so the reported values are consistent with `concentration_dict`.

## What it returns

A `dict[str, float]` mapping each constrained element to its chemical-potential shift `delta_mu` in eV, evaluated at the self-consistent Fermi level. These are shifts relative to the chemical-potential reference at which the formation energies were defined, not absolute chemical potentials.

- No `element_pools`: returns an empty dict.
- An element driven to the complete-exclusion limit (zero remaining target and no content-removing state) is reported as `-inf` (the `delta_mu -> -inf` limit).

## Why

Downstream tools (notably doped) need the chemical potential to judge whether a constrained concentration is physically accessible: whether `delta_mu` lies inside the host's thermodynamic stability region marks the difference between an accessible concentration and a supersaturated or otherwise unphysical state. py-sc-fermi cannot make that judgement itself, having no competing-phase data, but it can report the shift so a caller can.

## Sign convention (please confirm)

@alexsquires or @kavanase, please confirm this matches doped's expectation before this is relied upon. `delta_mu` is the shift relative to the formation-energy reference. Raising it raises the element's chemical potential and favours incorporation of defects containing it, so:

- a target above the unconstrained content gives `delta_mu > 0`
- a target below gives `delta_mu < 0`
- a target equal to the unconstrained content gives `delta_mu ~ 0`

## Scope

`concentration_dict`, the occupancy warning, serialisation, and the element-pool solver internals are unchanged.