### PR TITLE
Split defect_system.py pool plumbing and unify warning categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,13 +116,18 @@
   a lower temperature, e.g.
   `factory.at(T_low, fixed_concentrations={n: high[n] for n in frozen})`.
 - `DefectSystem` and `DefectSystemFactory` now emit a `DiluteLimitWarning`
-  (a dedicated `UserWarning` subclass), at most once per system, when a defect
+  (a dedicated warning subclass), at most once per system, when a defect
   species' solved site occupancy exceeds `occupancy_warning_threshold`
   (default 0.01, i.e. 1%; pass `None` to disable, or a finite fraction in
   (0, 1] to retune). py-sc-fermi models dilute, non-interacting defects, so a
   high occupancy flags a regime in which un-modelled defect-defect interactions
   may make the results non-physical. The threshold is a reporting preference
   and is not serialised.
+- Added a `PyScFermiWarning` base class so all py-sc-fermi warnings can be
+  filtered as a group. `DiluteLimitWarning` now subclasses it, and
+  `DefectChargeState.from_dict` emits the new `UnrecognisedKeyWarning` for
+  ignored keys rather than a bare `UserWarning`. All remain `UserWarning`
+  subclasses, so existing filters are unaffected.
 - Added `DefectSystem.element_chemical_potential_shifts`, which reports the
   solved chemical-potential shift (`delta_mu`, in eV) of each element
   constrained by `element_pools`, evaluated at the self-consistent Fermi

--- a/py_sc_fermi/defect_charge_state.py
+++ b/py_sc_fermi/defect_charge_state.py
@@ -5,7 +5,7 @@ import warnings
 import numpy as np
 from scipy.constants import physical_constants
 
-from py_sc_fermi.warnings import suppresses_numpy_overflow
+from py_sc_fermi.warnings import UnrecognisedKeyWarning, suppresses_numpy_overflow
 
 kboltz = physical_constants["Boltzmann constant in eV/K"][0]
 
@@ -93,6 +93,7 @@ class DefectChargeState:
         if unrecognised_keys:
             warnings.warn(
                 f"Ignoring unrecognised keys: {', '.join(unrecognised_keys)}",
+                UnrecognisedKeyWarning,
                 stacklevel=2,
             )
 

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -7,7 +7,7 @@ import warnings
 from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, NamedTuple, TypeAlias, TypedDict
+from typing import Any, NamedTuple
 
 import numpy as np
 from scipy.constants import physical_constants as _physical_constants
@@ -18,56 +18,20 @@ from py_sc_fermi.defect_charge_state import DefectChargeState
 from py_sc_fermi.defect_species import DefectSpecies
 from py_sc_fermi.dos import DOS
 from py_sc_fermi.element_pools import ElementPoolError
+from py_sc_fermi.pool_data import (
+    ElementPools,
+    ElementPoolsInput,
+    ElementPoolsResolved,
+    SitePools,
+    SitePoolsInput,
+    _element_pools_as_dict,
+    _normalise_element_pools,
+    _normalise_site_pools,
+    _site_pools_as_dict,
+)
+from py_sc_fermi.warnings import DiluteLimitWarning
 
 _kboltz = _physical_constants["Boltzmann constant in eV/K"][0]
-
-
-class DiluteLimitWarning(UserWarning):
-    """Warns that a defect's solved site occupancy is high enough that
-    py-sc-fermi's dilute, non-interacting-defect assumption may no longer hold,
-    so the results may be non-physical.
-
-    Emitted by :meth:`DefectSystem.get_sc_fermi` -- and therefore by every
-    results path that solves (``report``, ``concentration_dict``,
-    ``site_percentages``) -- when any species' occupancy exceeds
-    ``DefectSystem.occupancy_warning_threshold``, at most once per
-    ``DefectSystem`` instance. A dedicated ``UserWarning`` subclass so it can be
-    filtered independently of other warnings.
-    """
-
-
-# Pools as accepted by the constructor: each species given as a DefectSpecies
-# object or by its name.
-SitePoolsInput: TypeAlias = dict[str, tuple[float, list[DefectSpecies | str]]]
-ElementPoolsInput: TypeAlias = dict[str, tuple[float, list[tuple[DefectSpecies | str, float]]]]
-
-# Pools as stored on a DefectSystem: references reduced to names.
-SitePools: TypeAlias = dict[str, tuple[float, list[str]]]
-ElementPools: TypeAlias = dict[str, tuple[float, list[tuple[str, float]]]]
-
-# Element pools with names resolved back to roster DefectSpecies (solve time).
-ElementPoolsResolved: TypeAlias = dict[str, tuple[float, list[tuple[DefectSpecies, float]]]]
-
-
-class SerialisedSitePool(TypedDict):
-    """JSON/YAML form of one site pool: a named site budget and its species."""
-
-    n_sites: float
-    species: list[str]
-
-
-class SerialisedElementMember(TypedDict):
-    """JSON/YAML form of one (species, stoichiometry) member of an element pool."""
-
-    species: str
-    stoichiometry: float
-
-
-class SerialisedElementPool(TypedDict):
-    """JSON/YAML form of one element pool: a target content and its members."""
-
-    target: float
-    members: list[SerialisedElementMember]
 
 
 class _VariableState(NamedTuple):
@@ -95,55 +59,6 @@ class _ExclusionGroup:
 
     n_free: float
     variable_states: list[_VariableState]
-
-
-def _species_name(species: DefectSpecies | str) -> str:
-    """Reduce a species reference (a ``DefectSpecies`` or its name) to the name."""
-    return species.name if isinstance(species, DefectSpecies) else species
-
-
-def _normalise_site_pools(site_pools: SitePoolsInput | None) -> SitePools:
-    """Reduce every site-pool species reference to a species name."""
-    if not site_pools:
-        return {}
-    return {
-        pool_name: (n_sites, [_species_name(sp) for sp in species_list])
-        for pool_name, (n_sites, species_list) in site_pools.items()
-    }
-
-
-def _normalise_element_pools(element_pools: ElementPoolsInput | None) -> ElementPools:
-    """Reduce every element-pool species reference to a species name."""
-    if not element_pools:
-        return {}
-    return {
-        element: (target, [(_species_name(sp), stoich) for sp, stoich in pool_list])
-        for element, (target, pool_list) in element_pools.items()
-    }
-
-
-def _site_pools_as_dict(site_pools: SitePools) -> dict[str, SerialisedSitePool]:
-    """Serialise stored site pools to JSON/YAML-safe mappings."""
-    return {
-        pool_name: {"n_sites": float(n_sites), "species": list(species_names)}
-        for pool_name, (n_sites, species_names) in site_pools.items()
-    }
-
-
-def _element_pools_as_dict(
-    element_pools: ElementPools,
-) -> dict[str, SerialisedElementPool]:
-    """Serialise stored element pools to JSON/YAML-safe mappings."""
-    return {
-        element: {
-            "target": float(target),
-            "members": [
-                {"species": name, "stoichiometry": float(stoich)}
-                for name, stoich in pool_list
-            ],
-        }
-        for element, (target, pool_list) in element_pools.items()
-    }
 
 
 class DefectSystem:

--- a/py_sc_fermi/pool_data.py
+++ b/py_sc_fermi/pool_data.py
@@ -1,0 +1,97 @@
+"""Pool data shapes, reference normalisation, and serialisation for
+``DefectSystem`` site and element pools.
+
+These describe how pools are accepted from the caller (each species given
+as a ``DefectSpecies`` object or by name), how they are stored on a
+``DefectSystem`` (references reduced to names), and how they serialise to
+JSON/YAML. The element-pool chemical-potential solver is in
+``py_sc_fermi.element_pools``.
+"""
+
+from __future__ import annotations
+
+from typing import TypeAlias, TypedDict
+
+from py_sc_fermi.defect_species import DefectSpecies
+
+# Pools as accepted by the constructor: each species given as a DefectSpecies
+# object or by its name.
+SitePoolsInput: TypeAlias = dict[str, tuple[float, list[DefectSpecies | str]]]
+ElementPoolsInput: TypeAlias = dict[str, tuple[float, list[tuple[DefectSpecies | str, float]]]]
+
+# Pools as stored on a DefectSystem: references reduced to names.
+SitePools: TypeAlias = dict[str, tuple[float, list[str]]]
+ElementPools: TypeAlias = dict[str, tuple[float, list[tuple[str, float]]]]
+
+# Element pools with names resolved back to roster DefectSpecies (solve time).
+ElementPoolsResolved: TypeAlias = dict[str, tuple[float, list[tuple[DefectSpecies, float]]]]
+
+
+class SerialisedSitePool(TypedDict):
+    """JSON/YAML form of one site pool: a named site budget and its species."""
+
+    n_sites: float
+    species: list[str]
+
+
+class SerialisedElementMember(TypedDict):
+    """JSON/YAML form of one (species, stoichiometry) member of an element pool."""
+
+    species: str
+    stoichiometry: float
+
+
+class SerialisedElementPool(TypedDict):
+    """JSON/YAML form of one element pool: a target content and its members."""
+
+    target: float
+    members: list[SerialisedElementMember]
+
+
+def _species_name(species: DefectSpecies | str) -> str:
+    """Reduce a species reference (a ``DefectSpecies`` or its name) to the name."""
+    return species.name if isinstance(species, DefectSpecies) else species
+
+
+def _normalise_site_pools(site_pools: SitePoolsInput | None) -> SitePools:
+    """Reduce every site-pool species reference to a species name."""
+    if not site_pools:
+        return {}
+    return {
+        pool_name: (n_sites, [_species_name(sp) for sp in species_list])
+        for pool_name, (n_sites, species_list) in site_pools.items()
+    }
+
+
+def _normalise_element_pools(element_pools: ElementPoolsInput | None) -> ElementPools:
+    """Reduce every element-pool species reference to a species name."""
+    if not element_pools:
+        return {}
+    return {
+        element: (target, [(_species_name(sp), stoich) for sp, stoich in pool_list])
+        for element, (target, pool_list) in element_pools.items()
+    }
+
+
+def _site_pools_as_dict(site_pools: SitePools) -> dict[str, SerialisedSitePool]:
+    """Serialise stored site pools to JSON/YAML-safe mappings."""
+    return {
+        pool_name: {"n_sites": float(n_sites), "species": list(species_names)}
+        for pool_name, (n_sites, species_names) in site_pools.items()
+    }
+
+
+def _element_pools_as_dict(
+    element_pools: ElementPools,
+) -> dict[str, SerialisedElementPool]:
+    """Serialise stored element pools to JSON/YAML-safe mappings."""
+    return {
+        element: {
+            "target": float(target),
+            "members": [
+                {"species": name, "stoichiometry": float(stoich)}
+                for name, stoich in pool_list
+            ],
+        }
+        for element, (target, pool_list) in element_pools.items()
+    }

--- a/py_sc_fermi/warnings.py
+++ b/py_sc_fermi/warnings.py
@@ -7,7 +7,11 @@ from typing import ParamSpec, TypeVar
 import numpy as np
 
 
-class DiluteLimitWarning(UserWarning):
+class PyScFermiWarning(UserWarning):
+    """Base class for py-sc-fermi warnings, so callers can filter them as a group."""
+
+
+class DiluteLimitWarning(PyScFermiWarning):
     """Warns that a defect's solved site occupancy is high enough that
     py-sc-fermi's dilute, non-interacting-defect assumption may no longer hold,
     so the results may be non-physical.
@@ -16,9 +20,13 @@ class DiluteLimitWarning(UserWarning):
     results path that solves (``report``, ``concentration_dict``,
     ``site_percentages``) -- when any species' occupancy exceeds
     ``DefectSystem.occupancy_warning_threshold``, at most once per
-    ``DefectSystem`` instance. A dedicated ``UserWarning`` subclass so it can be
-    filtered independently of other warnings.
+    ``DefectSystem`` instance. A dedicated ``PyScFermiWarning`` subclass, so it
+    can be filtered on its own or together with other py-sc-fermi warnings.
     """
+
+
+class UnrecognisedKeyWarning(PyScFermiWarning):
+    """Warns that a ``from_dict`` input contained keys that were ignored."""
 
 
 P = ParamSpec("P")

--- a/py_sc_fermi/warnings.py
+++ b/py_sc_fermi/warnings.py
@@ -1,10 +1,25 @@
-"""Numpy overflow handling for py-sc-fermi."""
+"""Warning categories and numpy overflow handling for py-sc-fermi."""
 
 from collections.abc import Callable
 from functools import wraps
 from typing import ParamSpec, TypeVar
 
 import numpy as np
+
+
+class DiluteLimitWarning(UserWarning):
+    """Warns that a defect's solved site occupancy is high enough that
+    py-sc-fermi's dilute, non-interacting-defect assumption may no longer hold,
+    so the results may be non-physical.
+
+    Emitted by :meth:`DefectSystem.get_sc_fermi` -- and therefore by every
+    results path that solves (``report``, ``concentration_dict``,
+    ``site_percentages``) -- when any species' occupancy exceeds
+    ``DefectSystem.occupancy_warning_threshold``, at most once per
+    ``DefectSystem`` instance. A dedicated ``UserWarning`` subclass so it can be
+    filtered independently of other warnings.
+    """
+
 
 P = ParamSpec("P")
 R = TypeVar("R")

--- a/tests/test_defect_charge_state.py
+++ b/tests/test_defect_charge_state.py
@@ -4,6 +4,7 @@ import numpy as np
 import yaml
 
 from py_sc_fermi.defect_charge_state import DefectChargeState
+from py_sc_fermi.warnings import UnrecognisedKeyWarning
 
 
 class TestDefectChargeStateInit(unittest.TestCase):
@@ -194,15 +195,16 @@ class TestDefectChargeStateDictionaryOperations(unittest.TestCase):
         self.assertIsNone(dictionary["energy"])
         yaml.safe_dump(dictionary)
 
-    def test_defect_charge_state_from_dict_warns(self):
+    def test_defect_charge_state_from_dict_warns_unrecognised_key_category(self):
+        """from_dict emits UnrecognisedKeyWarning (not a bare UserWarning) for
+        keys it does not recognise."""
         dictionary = {
             "degeneracy": 2,
             "energy": 0.1234,
             "charge": 1,
-            "fixed_concentration": 0.1234,
-            "foo": "bar"
+            "foo": "bar",
         }
-        with self.assertWarns(UserWarning):
+        with self.assertWarns(UnrecognisedKeyWarning):
             DefectChargeState.from_dict(dictionary)
 
 

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -57,6 +57,26 @@ warnings.warn("test runtime warning", RuntimeWarning)
 
 class TestWarnings(unittest.TestCase):
         
+    def test_warnings_filter_as_a_group(self):
+        """A single filter on PyScFermiWarning catches every concrete
+        py-sc-fermi warning, and a UserWarning filter still catches them too --
+        so callers can surface or silence py-sc-fermi warnings as a group
+        without breaking existing UserWarning filters."""
+        from py_sc_fermi.warnings import (
+            DiluteLimitWarning,
+            PyScFermiWarning,
+            UnrecognisedKeyWarning,
+        )
+
+        concrete_warnings = (DiluteLimitWarning, UnrecognisedKeyWarning)
+        for group in (PyScFermiWarning, UserWarning):
+            for warning_cls in concrete_warnings:
+                with warnings.catch_warnings(record=True) as caught:
+                    warnings.simplefilter("ignore")
+                    warnings.simplefilter("always", group)
+                    warnings.warn("test", warning_cls, stacklevel=1)
+                self.assertEqual([w.category for w in caught], [warning_cls])
+
     def test_suppresses_numpy_overflow_decorator(self):
         """Decorator should suppress numpy overflow warnings."""
         from py_sc_fermi.warnings import suppresses_numpy_overflow


### PR DESCRIPTION
Splits two clusters out of the ~1480-line `defect_system.py` and unifies the package's warning categories. Two commits, the first pure code motion and the second a small backward-compatible change.

## Code motion (no behaviour change)

A new `py_sc_fermi.pool_data` module holds the site/element pool data shapes (type aliases and serialised `TypedDict`s), reference normalisation, and JSON/YAML serialisation. `DiluteLimitWarning` moves to `py_sc_fermi.warnings`, which already houses warning-related code. Both are re-imported into `defect_system`, so the public surface (`defect_system.DiluteLimitWarning`, the pool type aliases) is unchanged and the test suite passes unedited.

`pool_data` is the passive data side of the pool machinery, kept distinct from `py_sc_fermi.element_pools`, which is the numerical chemical-potential solver. `_VariableState`/`_ExclusionGroup` and the concentration-assembly methods are intentionally left in place for a later change.

## Warning-category unification (backward-compatible)

A new `PyScFermiWarning` base class lets all py-sc-fermi warnings be filtered as a group. `DiluteLimitWarning` now subclasses it, and `DefectChargeState.from_dict` emits a new `UnrecognisedKeyWarning` for ignored keys instead of a bare `UserWarning` (message and `stacklevel` unchanged). All remain `UserWarning` subclasses, so existing filters and assertions are unaffected.