### PR TITLE
Make DefectSystem public attributes read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@
   `SitePool(n_sites=..., species=[...])` and
   `ElementPool(target=..., members={...})`, both importable from
   `py_sc_fermi.pools`.
+- `DefectSystem`'s physical public attributes (`volume`, `dos`, `temperature`,
+  `convergence_tolerance`, `vbm_shift`, `cbm_shift`, `rigid_shift`,
+  `defect_species`, `site_pools`, `element_pools`) are now read-only; rebinding
+  any of them after construction raises `AttributeError`, enforcing the
+  documented immutable-snapshot contract. Construct a new `DefectSystem` (or use
+  `DefectSystemFactory.at(...)`) for a different temperature, DOS, or correction
+  set. `occupancy_warning_threshold`, a non-physical reporting preference, stays
+  settable and validates on assignment.
 
 ### Improvements
 

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -201,7 +201,7 @@ class DefectSystem:
         self._vbm_shift = vbm_shift
         self._cbm_shift = cbm_shift
         self._rigid_shift = rigid_shift
-        self.occupancy_warning_threshold = self._validate_occupancy_warning_threshold(
+        self._occupancy_warning_threshold = self._validate_occupancy_warning_threshold(
             occupancy_warning_threshold
         )
         self._occupancy_warning_emitted = False
@@ -257,6 +257,28 @@ class DefectSystem:
     @property
     def element_pools(self) -> dict[str, ElementPool]:
         return self._element_pools
+
+    @property
+    def occupancy_warning_threshold(self) -> float | None:
+        return self._occupancy_warning_threshold
+
+    @occupancy_warning_threshold.setter
+    def occupancy_warning_threshold(self, value: float | None) -> None:
+        """Set the dilute-limit warning threshold.
+
+        Validates ``value`` (see ``__init__``) and, when it differs from the
+        current threshold, re-arms the once-per-instance dilute-limit warning
+        so the next solve re-evaluates site occupancy against the new
+        threshold.
+
+        Raises:
+            ValueError: if ``value`` is not ``None`` or a finite fraction in
+                (0, 1].
+        """
+        validated = self._validate_occupancy_warning_threshold(value)
+        if validated != self._occupancy_warning_threshold:
+            self._occupancy_warning_emitted = False
+        self._occupancy_warning_threshold = validated
 
     @staticmethod
     def _validate_occupancy_warning_threshold(value: float | None) -> float | None:

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -165,12 +165,14 @@ class DefectSystem:
           is not ``None`` or a finite fraction in (0, 1].
 
     Note:
-        `DefectSystem` is an immutable, fixed-temperature snapshot:
-        `vbm_shift`, `cbm_shift`, `formation_energy_corrections`,
-        `rigid_shift`, and `fixed_concentrations` are applied once at
-        construction to copies of `defect_species` -- the objects passed in
-        (including any `formation_energy_corrections` keys) are never modified,
-        even temporarily. To build `DefectSystem`s at several temperatures from
+        `DefectSystem` is a fixed-temperature snapshot whose physical public
+        attributes are read-only once constructed: rebinding any of them raises
+        `AttributeError`. `vbm_shift`, `cbm_shift`,
+        `formation_energy_corrections`, `rigid_shift`, and
+        `fixed_concentrations` are applied once at construction to copies of
+        `defect_species` -- the objects passed in (including any
+        `formation_energy_corrections` keys) are never modified, even
+        temporarily. To build `DefectSystem`s at several temperatures from
         temperature-dependent shift/correction functions, see
         `DefectSystemFactory`.
     """

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -191,32 +191,72 @@ class DefectSystem:
         fixed_concentrations: dict[str, float] | None = None,
         occupancy_warning_threshold: float | None = 0.01,
     ):
-        self.volume = volume
-        self.dos = dos
+        self._volume = volume
+        self._dos = dos
         delta_gap = cbm_shift - vbm_shift
         if delta_gap != 0.0:
-            self.dos = self.dos.scissored(delta_gap)
-        self.temperature = temperature
-        self.convergence_tolerance = convergence_tolerance
-        self.vbm_shift = vbm_shift
-        self.cbm_shift = cbm_shift
-        self.rigid_shift = rigid_shift
+            self._dos = self._dos.scissored(delta_gap)
+        self._temperature = temperature
+        self._convergence_tolerance = convergence_tolerance
+        self._vbm_shift = vbm_shift
+        self._cbm_shift = cbm_shift
+        self._rigid_shift = rigid_shift
         self.occupancy_warning_threshold = self._validate_occupancy_warning_threshold(
             occupancy_warning_threshold
         )
         self._occupancy_warning_emitted = False
 
-        self.defect_species = copy.deepcopy(defect_species)
+        self._defect_species = copy.deepcopy(defect_species)
         self._apply_formation_energy_corrections(
             defect_species, formation_energy_corrections or {}
         )
 
-        self.site_pools: dict[str, SitePool] = dict(site_pools or {})
-        self.element_pools: dict[str, ElementPool] = dict(element_pools or {})
+        self._site_pools: dict[str, SitePool] = dict(site_pools or {})
+        self._element_pools: dict[str, ElementPool] = dict(element_pools or {})
 
         self._validate_pools()
         self._apply_fixed_concentrations(fixed_concentrations or {})
         self._validate_fixed_concentrations()
+
+    @property
+    def volume(self) -> float:
+        return self._volume
+
+    @property
+    def dos(self) -> DOS:
+        return self._dos
+
+    @property
+    def temperature(self) -> float:
+        return self._temperature
+
+    @property
+    def convergence_tolerance(self) -> float | None:
+        return self._convergence_tolerance
+
+    @property
+    def vbm_shift(self) -> float:
+        return self._vbm_shift
+
+    @property
+    def cbm_shift(self) -> float:
+        return self._cbm_shift
+
+    @property
+    def rigid_shift(self) -> bool:
+        return self._rigid_shift
+
+    @property
+    def defect_species(self) -> list[DefectSpecies]:
+        return self._defect_species
+
+    @property
+    def site_pools(self) -> dict[str, SitePool]:
+        return self._site_pools
+
+    @property
+    def element_pools(self) -> dict[str, ElementPool]:
+        return self._element_pools
 
     @staticmethod
     def _validate_occupancy_warning_threshold(value: float | None) -> float | None:

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -146,6 +146,25 @@ class TestDefectSystem(unittest.TestCase):
         self.assertEqual(self.defect_system.site_pools, {})
         self.assertEqual(self.defect_system.element_pools, {})
 
+    def test_occupancy_warning_threshold_setter_validates(self):
+        with self.assertRaises(ValueError):
+            self.defect_system.occupancy_warning_threshold = 1.5
+
+    def test_setting_threshold_re_arms_warning(self):
+        self.defect_system._occupancy_warning_emitted = True
+        self.defect_system.occupancy_warning_threshold = 0.5
+        self.assertFalse(self.defect_system._occupancy_warning_emitted)
+
+        self.defect_system._occupancy_warning_emitted = True
+        self.defect_system.occupancy_warning_threshold = 0.5
+        self.assertTrue(self.defect_system._occupancy_warning_emitted)
+
+    def test_occupancy_warning_threshold_is_settable(self):
+        self.defect_system.occupancy_warning_threshold = 0.5
+        self.assertEqual(self.defect_system.occupancy_warning_threshold, 0.5)
+        self.defect_system.occupancy_warning_threshold = None
+        self.assertIsNone(self.defect_system.occupancy_warning_threshold)
+
     def test_total_defect_charge_contributions(self):
         cs_pos = DefectChargeState(charge=1, fixed_concentration=2)
         cs_neg = DefectChargeState(charge=-1, fixed_concentration=3)

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -118,6 +118,34 @@ class TestDefectSystem(unittest.TestCase):
     def test_defect_species_names(self):
         self.assertEqual(self.defect_system.defect_species_names, ["v_O", "O_i"])
 
+    def test_public_attributes_are_read_only(self):
+        new_values = {
+            "volume": 1.0,
+            "dos": Mock(spec=DOS),
+            "temperature": 1.0,
+            "convergence_tolerance": 1.0,
+            "vbm_shift": 1.0,
+            "cbm_shift": 1.0,
+            "rigid_shift": False,
+            "defect_species": [],
+            "site_pools": {},
+            "element_pools": {},
+        }
+        for name, value in new_values.items():
+            with self.subTest(attribute=name):
+                with self.assertRaises(AttributeError):
+                    setattr(self.defect_system, name, value)
+
+    def test_public_attribute_reads_return_constructed_values(self):
+        self.assertEqual(self.defect_system.volume, 100)
+        self.assertEqual(self.defect_system.temperature, 298)
+        self.assertIsNone(self.defect_system.convergence_tolerance)
+        self.assertEqual(self.defect_system.vbm_shift, 0.0)
+        self.assertEqual(self.defect_system.cbm_shift, 0.0)
+        self.assertTrue(self.defect_system.rigid_shift)
+        self.assertEqual(self.defect_system.site_pools, {})
+        self.assertEqual(self.defect_system.element_pools, {})
+
     def test_total_defect_charge_contributions(self):
         cs_pos = DefectChargeState(charge=1, fixed_concentration=2)
         cs_neg = DefectChargeState(charge=-1, fixed_concentration=3)

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -135,8 +135,13 @@ class TestDefectSystem(unittest.TestCase):
         self.assertEqual(self.defect_system.q_tot(2), 0)
 
     def test_as_dict(self):
-        self.defect_system.dos = DOS.from_vasprun(test_vasprun_filename, nelect=12)
-        defect_dict = self.defect_system.as_dict()
+        system = DefectSystem(
+            defect_species=self.defect_system.defect_species,
+            volume=100,
+            dos=DOS.from_vasprun(test_vasprun_filename, nelect=12),
+            temperature=298,
+        )
+        defect_dict = system.as_dict()
         self.assertEqual(defect_dict["volume"], 100)
         self.assertEqual(defect_dict["temperature"], 298)
 
@@ -291,7 +296,6 @@ class TestDefectSystem(unittest.TestCase):
         self.defect_system.defect_species[1].nsites = 1
         self.defect_system.defect_species[0].name = "v_O"
         self.defect_system.defect_species[1].name = "O_i"
-        self.defect_system.volume = 100
 
         expected_dict = {
             "Fermi Energy": 1.0,
@@ -316,11 +320,17 @@ class TestDefectSystem(unittest.TestCase):
 
 
     def test__repr__(self):
-        self.defect_system.defect_species = []
-        self.defect_system.dos.nelect = 100
-        self.defect_system.dos.bandgap = 0.1
+        dos = Mock(spec=DOS)
+        dos.nelect = 100
+        dos.bandgap = 0.1
+        system = DefectSystem(
+            defect_species=[],
+            volume=100,
+            dos=dos,
+            temperature=298,
+        )
         self.assertEqual(
-            str(self.defect_system).strip(),
+            str(system).strip(),
             "DefectSystem\n"
             "  bandgap:     0.1 eV    nelect: 100\n"
             "  volume:      100 Å³    temperature: 298 K\n"

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -150,15 +150,6 @@ class TestDefectSystem(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.defect_system.occupancy_warning_threshold = 1.5
 
-    def test_setting_threshold_re_arms_warning(self):
-        self.defect_system._occupancy_warning_emitted = True
-        self.defect_system.occupancy_warning_threshold = 0.5
-        self.assertFalse(self.defect_system._occupancy_warning_emitted)
-
-        self.defect_system._occupancy_warning_emitted = True
-        self.defect_system.occupancy_warning_threshold = 0.5
-        self.assertTrue(self.defect_system._occupancy_warning_emitted)
-
     def test_occupancy_warning_threshold_is_settable(self):
         self.defect_system.occupancy_warning_threshold = 0.5
         self.assertEqual(self.defect_system.occupancy_warning_threshold, 0.5)
@@ -2985,6 +2976,29 @@ class TestDiluteLimitWarning(unittest.TestCase):
             system.concentration_dict()
             system.get_sc_fermi()
         self.assertEqual(len(self._dilute_warnings(records)), 1)
+
+    def test_changing_threshold_re_arms_warning_for_next_solve(self):
+        # The once-per-instance guard silences repeat warnings for a solved
+        # system. Changing the threshold re-arms it so the next solve warns
+        # again; re-setting the same value leaves it silent.
+        system = self._make_system([self._saturating_species("S")])
+
+        with warnings.catch_warnings(record=True) as first:
+            warnings.simplefilter("always")
+            system.get_sc_fermi()
+        self.assertEqual(len(self._dilute_warnings(first)), 1)
+
+        system.occupancy_warning_threshold = 0.5
+        with warnings.catch_warnings(record=True) as after_change:
+            warnings.simplefilter("always")
+            system.get_sc_fermi()
+        self.assertEqual(len(self._dilute_warnings(after_change)), 1)
+
+        system.occupancy_warning_threshold = 0.5
+        with warnings.catch_warnings(record=True) as after_same:
+            warnings.simplefilter("always")
+            system.get_sc_fermi()
+        self.assertEqual(self._dilute_warnings(after_same), [])
 
     def test_threshold_absent_from_as_dict(self):
         system = self._make_system(


### PR DESCRIPTION
Makes `DefectSystem` an enforced immutable snapshot. The class documents its
inputs as "applied once at construction" and "never modified", but every public
attribute was a plain writable field, so a caller could silently rebind
`system.temperature`, `system.dos`, and so on. This makes that contract true.

## What changes

- The ten physical public attributes (`volume`, `dos`, `temperature`,
  `convergence_tolerance`, `vbm_shift`, `cbm_shift`, `rigid_shift`,
  `defect_species`, `site_pools`, `element_pools`) become read-only properties
  over private backing fields. Rebinding any of them raises `AttributeError`,
  and because they are real read-only properties, mypy flags the rebind at the
  call site for typed downstreams. `__init__` writes the backing fields,
  including the band-gap scissor.
- `occupancy_warning_threshold` stays settable. It is a reporting preference,
  not part of the physical system, and is not serialised. Its setter validates
  the value (as the constructor does) and re-arms the once-per-instance
  dilute-limit warning when the value changes, so the next solve re-evaluates
  occupancy against the new threshold.
- Only the attribute bindings are frozen, not the contained objects. Reaching
  into the private state of the contained species or DOS is unchanged.
- `DefectSystemFactory` is untouched; it is a mutable builder.

This is a v3 breaking change and is recorded in the changelog. The one known
consumer that rebinds these attributes (doped's anneal-and-quench reassigning
`temperature`) has agreed to migrate, and its released code targets v2.