### PR TITLE
Accept name pairs as formation-energy-correction keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,11 @@
 - Added `DefectSpecies.charge_state_by_name`, mirroring
   `DefectSystem.defect_species_by_name`; raises `ValueError` listing the
   available names when no charge state matches.
+- `formation_energy_corrections` (`DefectSystem`) and
+  `formation_energy_correction_fns` (`DefectSystemFactory`) accept
+  `(species_name, charge_state_name)` pairs as keys, alongside
+  `DefectChargeState` objects. Referencing the same charge state through two
+  keys raises `ValueError`.
 - Added `DefectSystem.charge_state_concentration_dict(per_volume=True)`, which
   returns `{species_name: {charge_state_name: conc}}` with one entry per
   `DefectChargeState`. It returns the same per-species entries as
@@ -123,24 +128,24 @@
   self-consistent Fermi level, as well as the effective band gap shown by
   `__repr__`/`report`. The new `DOS.scissored(delta_gap)` performs this shift
   and returns a new `DOS`. `formation_energy_corrections` is a
-  `dict[DefectChargeState, float]` of per-charge-state formation-energy
-  corrections, keyed by the `DefectChargeState` objects themselves so that
-  metastable states sharing a formal charge can be corrected independently. If
-  `rigid_shift` is True (the default), the band structure and defect levels are
-  assumed to move together as a rigid body, so any variable-concentration
-  charge state not covered by `formation_energy_corrections` is unchanged; if
-  False, such charge states have their formation energy shifted by
-  `-charge * vbm_shift`. The DOS scissor and the formation-energy channel are
-  independent. `DefectSystem` is an immutable, fixed-temperature snapshot:
+  `dict` of per-charge-state formation-energy corrections, keyed by the
+  `DefectChargeState` object or a `(species_name, charge_state_name)` pair,
+  so that metastable states sharing a formal charge can be corrected
+  independently. If `rigid_shift` is True (the default), the band structure
+  and defect levels are assumed to move together as a rigid body, so any
+  variable-concentration charge state not covered by
+  `formation_energy_corrections` is unchanged; if False, such charge states
+  have their formation energy shifted by `-charge * vbm_shift`. The DOS
+  scissor and the formation-energy channel are independent. `DefectSystem` is an immutable, fixed-temperature snapshot:
   corrections are applied once at construction to copies of `defect_species`
   (and to a private scissored DOS), the caller's objects are never modified,
   and `report()`/`as_dict()`/`from_dict()` always agree.
 - Added `DefectSystemFactory`, for building `DefectSystem` snapshots at a
   series of temperatures from temperature-dependent `vbm_shift_fn`,
   `cbm_shift_fn` and `formation_energy_correction_fns` (each a function of
-  temperature; the latter a `dict[DefectChargeState, Callable[[float], float]]`
-  of temperature-dependent formation-energy corrections, e.g. vibrational
-  free-energy contributions). `factory.at(T,
+  temperature; the latter a `dict` of temperature-dependent formation-energy
+  corrections keyed per charge state, e.g. vibrational free-energy
+  contributions). `factory.at(T,
   **overrides)` evaluates these functions at `T` and returns an independent
   `DefectSystem`, e.g. `{T: factory.at(T).concentration_dict() for T in
   temperatures}`.
@@ -148,10 +153,10 @@
   mapping species name to a fixed total concentration per unit cell, applied by
   name to the constructor's own copies of `defect_species` (overriding any
   species-level `fixed_concentration` they were constructed with, and composing
-  with `formation_energy_corrections`, which are resolved by identity). This makes
-  the anneal-and-quench override documented on `DefectSystemFactory.at` work:
-  freeze some species' totals at their high-temperature values and re-solve at
-  a lower temperature, e.g.
+  with `formation_energy_corrections`, keyed by object or by name pair). This
+  makes the anneal-and-quench override documented on `DefectSystemFactory.at`
+  work: freeze some species' totals at their high-temperature values and
+  re-solve at a lower temperature, e.g.
   `factory.at(T_low, fixed_concentrations={n: high[n] for n in frozen})`.
 - `DefectSystem` and `DefectSystemFactory` now emit a `DiluteLimitWarning`
   (a dedicated warning subclass), at most once per system, when a defect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,8 @@
   `formation_energy_correction_fns` (`DefectSystemFactory`) accept
   `(species_name, charge_state_name)` pairs as keys, alongside
   `DefectChargeState` objects. Referencing the same charge state through two
-  keys raises `ValueError`.
+  keys, keying a fixed-concentration state (which has no formation energy to
+  correct), or passing a key that is neither form raises `ValueError`.
 - Added `DefectSystem.charge_state_concentration_dict(per_volume=True)`, which
   returns `{species_name: {charge_state_name: conc}}` with one entry per
   `DefectChargeState`. It returns the same per-species entries as
@@ -136,7 +137,8 @@
   variable-concentration charge state not covered by
   `formation_energy_corrections` is unchanged; if False, such charge states
   have their formation energy shifted by `-charge * vbm_shift`. The DOS
-  scissor and the formation-energy channel are independent. `DefectSystem` is an immutable, fixed-temperature snapshot:
+  scissor and the formation-energy channel are independent. `DefectSystem`
+  is an immutable, fixed-temperature snapshot:
   corrections are applied once at construction to copies of `defect_species`
   (and to a private scissored DOS), the caller's objects are never modified,
   and `report()`/`as_dict()`/`from_dict()` always agree.

--- a/docs/source/migrating_to_v3.rst
+++ b/docs/source/migrating_to_v3.rst
@@ -202,25 +202,22 @@ Temperature-dependent formation-energy corrections
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``DefectSystemFactory`` accepts ``formation_energy_correction_fns``, a mapping
-from a ``DefectChargeState`` to an arbitrary function of temperature. The
-function is evaluated at each snapshot and the result is added to that charge
-state's formation energy. This is the natural place for corrections whose
-magnitude varies with temperature — for example, vibrational free-energy
-corrections from phonon calculations:
+from a charge state to an arbitrary function of temperature. Each key
+identifies the charge state either as a ``(species_name, charge_state_name)``
+pair or as the ``DefectChargeState`` object itself. The function is evaluated
+at each snapshot and the result is added to that charge state's formation
+energy. This is the natural place for corrections whose magnitude varies with
+temperature — for example, vibrational free-energy corrections from phonon
+calculations:
 
 .. code-block:: python
-
-    # Keep a reference to the charge state so it can be used as a key below.
-    # Matching is by object identity, so this must be the same object passed
-    # into DefectSpecies.
-    v_o_2plus = DefectChargeState(charge=2, energy=1.2, degeneracy=1, name="V_O_2+")
 
     v_O = DefectSpecies(
         name="V_O",
         nsites=1,
         charge_states=[
             DefectChargeState(charge=0, energy=0.0, degeneracy=1, name="V_O_0"),
-            v_o_2plus,
+            DefectChargeState(charge=2, energy=1.2, degeneracy=1, name="V_O_2+"),
         ],
     )
 
@@ -229,7 +226,7 @@ corrections from phonon calculations:
         dos=dos,
         volume=volume,
         formation_energy_correction_fns={
-            v_o_2plus: lambda T: vibrational_free_energy(T),
+            ("V_O", "V_O_2+"): lambda T: vibrational_free_energy(T),
         },
     )
 
@@ -238,8 +235,7 @@ corrections from phonon calculations:
 At each temperature the correction is re-evaluated and baked into the formation
 energy before the self-consistent Fermi level is solved. ``DefectSystem``
 itself (for a single temperature) accepts the pre-evaluated version as
-``formation_energy_corrections: dict[DefectChargeState, float]`` if you do not
-need a sweep.
+``formation_energy_corrections``, with the same choice of key forms.
 
 Also new
 ~~~~~~~~

--- a/docs/source/tutorial.ipynb
+++ b/docs/source/tutorial.ipynb
@@ -1135,7 +1135,7 @@
     "\n",
     "- `vbm_shift` / `cbm_shift`: shifts (in eV) of the valence-band maximum and conduction-band minimum. They scissor the DOS so the band gap changes by `cbm_shift - vbm_shift` (the VBM is pinned at E=0), which moves the carrier concentrations and the self-consistent Fermi level, and sets the displayed band gap.\n",
     "- `rigid_shift` (default `True`): gates the formation-energy channel only; the DOS scissor always applies. If the band structure and defect levels move together as a rigid body, formation energies are unchanged. If `False`, the defect levels are fixed in absolute energy while the bands move, so each variable-concentration charge state's formation energy shifts by `-charge * vbm_shift`.\n",
-    "- `formation_energy_corrections`: a `dict[DefectChargeState, float]` of one-off corrections (e.g. from a hybrid-functional or GW calculation) for specific charge states, keyed by the `DefectChargeState` objects themselves so that metastable states sharing a charge can be corrected independently.\n",
+    "- `formation_energy_corrections`: a `dict` of one-off corrections (e.g. from a hybrid-functional or GW calculation) for specific charge states, keyed per charge state — as `(species_name, charge_state_name)` pairs or the `DefectChargeState` objects themselves — so that metastable states sharing a charge can be corrected independently.\n",
     "\n",
     "As we saw earlier, `DefectSystem` is an immutable snapshot: corrections are applied once, to copies of `defect_species`, at construction — the original objects passed in are never modified."
    ]

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -128,8 +128,10 @@ class DefectSystem:
           mixed. Keying per charge state (rather than per formal charge)
           allows different corrections for metastable states that share a
           formal charge. Every key must identify a charge state in
-          `defect_species`, and no charge state may be referenced twice.
-          Defaults to None (no per-state corrections).
+          `defect_species` that has a formation energy (a fixed-concentration
+          state has nothing for a correction to act on), and no charge state
+          may be referenced twice. Defaults to None (no per-state
+          corrections).
         rigid_shift (bool, optional): gates only the formation-energy channel;
           the DOS scissor from `vbm_shift`/`cbm_shift` is applied regardless. If
           True (the default), the band structure and defect levels are assumed
@@ -339,13 +341,15 @@ class DefectSystem:
         ``defect_species``; ``DefectChargeState`` keys pass through unchanged.
 
         Raises:
-            ValueError: if a pair names an unknown species or charge state,
-                or if two keys resolve to the same charge state.
+            ValueError: if a key is neither form, a pair names an unknown
+                species or charge state, the charge state has no formation
+                energy for a correction to act on (fixed concentration), or
+                two keys resolve to the same charge state.
         """
         species_by_name = {ds.name: ds for ds in defect_species}
         resolved: dict[DefectChargeState, float] = {}
         for key, value in corrections.items():
-            if isinstance(key, tuple):
+            if isinstance(key, tuple) and len(key) == 2:
                 species_name, cs_name = key
                 if species_name not in species_by_name:
                     available = ", ".join(species_by_name)
@@ -354,8 +358,24 @@ class DefectSystem:
                         f"available: {available}"
                     )
                 cs = species_by_name[species_name].charge_state_by_name(cs_name)
-            else:
+            elif isinstance(key, DefectChargeState):
                 cs = key
+            else:
+                raise ValueError(
+                    "formation_energy_corrections keys must be "
+                    "DefectChargeState objects or "
+                    f"(species_name, charge_state_name) pairs; got {key!r}."
+                )
+            if cs.energy is None:
+                owner = next(
+                    (ds.name for ds in defect_species if cs in ds.charge_states),
+                    "<unknown>",
+                )
+                raise ValueError(
+                    f"formation_energy_corrections references charge state "
+                    f"'{cs.name}' of species '{owner}', which has no formation "
+                    "energy (fixed concentration) and cannot be corrected."
+                )
             if cs in resolved:
                 owner = next(
                     (ds.name for ds in defect_species if cs in ds.charge_states),

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -144,7 +144,7 @@ class DefectSystem:
           overriding any species-level `fixed_concentration` it was constructed
           with. The fix is applied by name to this system's own copies of
           `defect_species`, so it composes with `formation_energy_corrections`
-          (resolved by identity against the passed-in objects) and never
+          (resolved against the passed-in `defect_species`) and never
           mutates the caller's species. A non-finite or negative value, or one
           that cannot be hosted (above its site-exclusion group's site budget
           -- its own `nsites`, or its shared `site_pools` size -- or below its

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -1480,12 +1480,14 @@ class DefectSystemFactory:
         cbm_shift_fn (Callable[[float], float] | None, optional): a function
           of temperature returning the conduction-band-minimum shift (in eV)
           at that temperature. Defaults to None (no shift).
-        formation_energy_correction_fns (dict[DefectChargeState, Callable[[float], float]] | None,
+        formation_energy_correction_fns (dict[CorrectionKey, Callable[[float], float]] | None,
           optional): per-charge-state temperature-dependent formation-energy
           corrections. Each callable takes a temperature in K and returns a
           correction in eV to add to that charge state's formation energy at
-          each snapshot. Keys must be `DefectChargeState` objects in
-          `defect_species`, matched by identity. Defaults to None.
+          each snapshot. Keys identify a charge state either as the
+          `DefectChargeState` object or as a `(species_name, charge_state_name)`
+          pair; they are resolved when `at()` builds each `DefectSystem`.
+          Defaults to None.
         rigid_shift (bool, optional): passed to every `DefectSystem` built by
           `at()`. Defaults to True.
         occupancy_warning_threshold (float | None, optional): passed to every
@@ -1505,7 +1507,7 @@ class DefectSystemFactory:
         vbm_shift_fn: Callable[[float], float] | None = None,
         cbm_shift_fn: Callable[[float], float] | None = None,
         formation_energy_correction_fns: (
-            dict[DefectChargeState, Callable[[float], float]] | None
+            dict[CorrectionKey, Callable[[float], float]] | None
         ) = None,
         rigid_shift: bool = True,
         occupancy_warning_threshold: float | None = 0.01,

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -27,6 +27,11 @@ from py_sc_fermi.warnings import DiluteLimitWarning
 
 _kboltz = _physical_constants["Boltzmann constant in eV/K"][0]
 
+CorrectionKey = DefectChargeState | tuple[str, str]
+"""A formation-energy-correction key: a ``DefectChargeState`` object, or a
+``(species_name, charge_state_name)`` pair resolved against the system's
+defect species."""
+
 
 class _VariableState(NamedTuple):
     """A non-fixed-concentration charge state within an exclusion group,
@@ -115,13 +120,15 @@ class DefectSystem:
           gap changes by `cbm_shift - vbm_shift`, moving the conduction block
           (and the carrier concentrations) and setting the effective band gap
           shown by `__repr__`/`report`. Defaults to 0.0 (no shift).
-        formation_energy_corrections (dict[DefectChargeState, float] | None, optional):
+        formation_energy_corrections (dict[CorrectionKey, float] | None, optional):
           per-charge-state formation-energy corrections (in eV), evaluated by
-          the caller for this system's `temperature`. Keying by the
-          `DefectChargeState` object itself (rather than e.g.
-          `(species_name, charge)`) allows different corrections for
-          metastable `DefectChargeState`s that share a formal charge. Every
-          key must be one of the `DefectChargeState`s in `defect_species`.
+          the caller for this system's `temperature`. Each key identifies one
+          charge state, either as the `DefectChargeState` object itself or as
+          a `(species_name, charge_state_name)` pair; the two forms may be
+          mixed. Keying per charge state (rather than per formal charge)
+          allows different corrections for metastable states that share a
+          formal charge. Every key must identify a charge state in
+          `defect_species`, and no charge state may be referenced twice.
           Defaults to None (no per-state corrections).
         rigid_shift (bool, optional): gates only the formation-energy channel;
           the DOS scissor from `vbm_shift`/`cbm_shift` is applied regardless. If
@@ -188,7 +195,7 @@ class DefectSystem:
         element_pools: dict[str, ElementPool] | None = None,
         vbm_shift: float = 0.0,
         cbm_shift: float = 0.0,
-        formation_energy_corrections: dict[DefectChargeState, float] | None = None,
+        formation_energy_corrections: dict[CorrectionKey, float] | None = None,
         rigid_shift: bool = True,
         fixed_concentrations: dict[str, float] | None = None,
         occupancy_warning_threshold: float | None = 0.01,
@@ -209,14 +216,13 @@ class DefectSystem:
         self._occupancy_warning_emitted = False
 
         self._defect_species = copy.deepcopy(defect_species)
+        self._site_pools: dict[str, SitePool] = dict(site_pools or {})
+        self._element_pools: dict[str, ElementPool] = dict(element_pools or {})
+        self._validate_pools()
+
         self._apply_formation_energy_corrections(
             defect_species, formation_energy_corrections or {}
         )
-
-        self._site_pools: dict[str, SitePool] = dict(site_pools or {})
-        self._element_pools: dict[str, ElementPool] = dict(element_pools or {})
-
-        self._validate_pools()
         self._apply_fixed_concentrations(fixed_concentrations or {})
         self._validate_fixed_concentrations()
 
@@ -322,21 +328,67 @@ class DefectSystem:
         for name, conc in fixed_concentrations.items():
             self.defect_species_by_name(name).fix_concentration(conc)
 
+    @staticmethod
+    def _resolve_correction_keys(
+        defect_species: list[DefectSpecies],
+        corrections: dict[CorrectionKey, float],
+    ) -> dict[DefectChargeState, float]:
+        """Canonicalise correction keys to ``DefectChargeState`` objects.
+
+        ``(species_name, charge_state_name)`` keys are resolved against
+        ``defect_species``; ``DefectChargeState`` keys pass through unchanged.
+
+        Raises:
+            ValueError: if a pair names an unknown species or charge state,
+                or if two keys resolve to the same charge state.
+        """
+        species_by_name = {ds.name: ds for ds in defect_species}
+        resolved: dict[DefectChargeState, float] = {}
+        for key, value in corrections.items():
+            if isinstance(key, tuple):
+                species_name, cs_name = key
+                if species_name not in species_by_name:
+                    available = ", ".join(species_by_name)
+                    raise ValueError(
+                        f"no defect species named '{species_name}'; "
+                        f"available: {available}"
+                    )
+                cs = species_by_name[species_name].charge_state_by_name(cs_name)
+            else:
+                cs = key
+            if cs in resolved:
+                owner = next(
+                    (ds.name for ds in defect_species if cs in ds.charge_states),
+                    "<unknown>",
+                )
+                raise ValueError(
+                    "formation_energy_corrections contains more than one key for "
+                    f"charge state '{cs.name}' of species '{owner}'."
+                )
+            resolved[cs] = value
+        return resolved
+
     def _apply_formation_energy_corrections(
         self,
         original_defect_species: list[DefectSpecies],
-        formation_energy_corrections: dict[DefectChargeState, float],
+        formation_energy_corrections: dict[CorrectionKey, float],
     ) -> None:
         """Permanently shift each variable-concentration charge state's
         formation energy in `self.defect_species` (a copy of
-        `original_defect_species`) by `formation_energy_corrections[cs]` if
-        present, else `-cs.charge * self.vbm_shift` if `self.rigid_shift` is
-        False, else 0.
+        `original_defect_species`) by its entry in
+        `formation_energy_corrections` if present, else
+        `-cs.charge * self.vbm_shift` if `self.rigid_shift` is False, else 0.
+        Keys are `DefectChargeState` objects or
+        `(species_name, charge_state_name)` pairs, canonicalised to objects
+        before use.
         """
+        resolved_corrections = self._resolve_correction_keys(
+            original_defect_species, formation_energy_corrections
+        )
         original_states = [cs for ds in original_defect_species for cs in ds.charge_states]
         copied_states = [cs for ds in self.defect_species for cs in ds.charge_states]
 
-        unrecognised = set(formation_energy_corrections) - set(original_states)
+        unrecognised = set(resolved_corrections) - set(original_states)
         if unrecognised:
             raise ValueError(
                 f"formation_energy_corrections references "
@@ -347,8 +399,8 @@ class DefectSystem:
         for original_cs, copied_cs in zip(original_states, copied_states, strict=True):
             if copied_cs._energy is None:
                 continue
-            if original_cs in formation_energy_corrections:
-                delta = formation_energy_corrections[original_cs]
+            if original_cs in resolved_corrections:
+                delta = resolved_corrections[original_cs]
             elif not self.rigid_shift:
                 delta = -copied_cs.charge * self.vbm_shift
             else:

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -2214,6 +2214,109 @@ class TestDefectSystemBandEdgeCorrections(unittest.TestCase):
         with self.assertRaises(ValueError):
             self._make_system(formation_energy_corrections={unknown_cs: 0.1})
 
+    def _corrected_x_concentrations(self, corrections_for):
+        """Solve a two-state species with corrections built by ``corrections_for``.
+
+        ``corrections_for(cs_a, cs_b)`` returns the formation_energy_corrections
+        dict, so tests can key by object, by name pair, or a mixture.
+        """
+        cs_a = DefectChargeState(charge=0, energy=1.0, name="X_a")
+        cs_b = DefectChargeState(charge=0, energy=1.5, name="X_b")
+        ds = DefectSpecies(name="X", nsites=1, charge_states=[cs_a, cs_b])
+        dos = Mock(spec=DOS)
+        dos.bandgap = 1.0
+        dos.nelect = 10
+        system = DefectSystem(
+            defect_species=[ds],
+            volume=1.0,
+            dos=dos,
+            temperature=300,
+            formation_energy_corrections=corrections_for(cs_a, cs_b),
+        )
+        system.get_sc_fermi = Mock(return_value=[0.5, {}])
+        return system.charge_state_concentration_dict(per_volume=False)["X"]
+
+    def test_formation_energy_corrections_accept_name_pairs(self):
+        by_object = self._corrected_x_concentrations(lambda cs_a, cs_b: {cs_a: 0.2})
+        by_name = self._corrected_x_concentrations(
+            lambda cs_a, cs_b: {("X", "X_a"): 0.2}
+        )
+        self.assertEqual(by_object, by_name)
+
+    def test_formation_energy_corrections_accept_mixed_keys(self):
+        by_objects = self._corrected_x_concentrations(
+            lambda cs_a, cs_b: {cs_a: 0.2, cs_b: 0.1}
+        )
+        mixed = self._corrected_x_concentrations(
+            lambda cs_a, cs_b: {cs_a: 0.2, ("X", "X_b"): 0.1}
+        )
+        self.assertEqual(by_objects, mixed)
+
+    def test_correction_with_unknown_species_name_raises(self):
+        with self.assertRaisesRegex(ValueError, "no defect species named 'Y'"):
+            self._corrected_x_concentrations(
+                lambda cs_a, cs_b: {("Y", "X_a"): 0.2}
+            )
+
+    def test_correction_with_unknown_charge_state_name_raises(self):
+        with self.assertRaisesRegex(ValueError, "available: X_a, X_b"):
+            self._corrected_x_concentrations(
+                lambda cs_a, cs_b: {("X", "nope"): 0.2}
+            )
+
+    def test_duplicate_correction_reference_raises(self):
+        # The same charge state referenced by object and by name pair.
+        with self.assertRaisesRegex(ValueError, "X_a"):
+            self._corrected_x_concentrations(
+                lambda cs_a, cs_b: {cs_a: 0.2, ("X", "X_a"): 0.1}
+            )
+
+    def test_name_pair_correction_targets_the_right_species(self):
+        # Two species each have a default-named "q+0" state; the pair key
+        # must correct only the named species' state.
+        a_state = DefectChargeState(charge=0, energy=1.0)
+        b_state = DefectChargeState(charge=0, energy=2.0)
+        ds_a = DefectSpecies(name="A", nsites=1, charge_states=[a_state])
+        ds_b = DefectSpecies(name="B", nsites=1, charge_states=[b_state])
+        dos = Mock(spec=DOS)
+        dos.bandgap = 1.0
+        dos.nelect = 10
+        system = DefectSystem(
+            defect_species=[ds_a, ds_b],
+            volume=1.0,
+            dos=dos,
+            temperature=300,
+            formation_energy_corrections={("B", "q+0"): 0.3},
+        )
+        corrected_b = system.defect_species_by_name("B").charge_state_by_name("q+0")
+        untouched_a = system.defect_species_by_name("A").charge_state_by_name("q+0")
+        self.assertAlmostEqual(corrected_b.energy, 2.3)
+        self.assertAlmostEqual(untouched_a.energy, 1.0)
+        self.assertAlmostEqual(a_state.energy, 1.0)   # caller's objects untouched
+        self.assertAlmostEqual(b_state.energy, 2.0)
+
+    def test_duplicate_species_names_beat_correction_resolution(self):
+        # Structural validation must run before correction-key resolution,
+        # so the user sees the duplicate-names error, not a resolver error.
+        # The key names a state on the first duplicate, which the resolver's
+        # name map would shadow with the second, so resolving first would
+        # raise a confusing "no charge state named ..." error instead.
+        cs_1 = DefectChargeState(charge=0, energy=1.0)
+        cs_2 = DefectChargeState(charge=1, energy=1.0)
+        dup_a = DefectSpecies(name="X", nsites=1, charge_states=[cs_1])
+        dup_b = DefectSpecies(name="X", nsites=1, charge_states=[cs_2])
+        dos = Mock(spec=DOS)
+        dos.bandgap = 1.0
+        dos.nelect = 10
+        with self.assertRaisesRegex(ValueError, "duplicate names"):
+            DefectSystem(
+                defect_species=[dup_a, dup_b],
+                volume=1.0,
+                dos=dos,
+                temperature=300,
+                formation_energy_corrections={("X", "q+0"): 0.1},
+            )
+
     def test_cbm_shift_moves_carriers(self):
         base = self._make_system()
         shifted = self._make_system(cbm_shift=0.5)  # delta_gap = +0.5 (widen)

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -2412,6 +2412,47 @@ class TestDefectSystemFactory(unittest.TestCase):
         self.assertAlmostEqual(system.defect_species[0].charge_states[0].energy, 0.5 + 0.3)
         self.assertAlmostEqual(system.defect_species[0].charge_states[1].energy, 0.9 - 0.15)
 
+    def _factory_corrected_x_concentrations(self, correction_fns_for):
+        cs_a = DefectChargeState(charge=0, energy=1.0, name="X_a")
+        cs_b = DefectChargeState(charge=0, energy=1.5, name="X_b")
+        ds = DefectSpecies(name="X", nsites=1, charge_states=[cs_a, cs_b])
+        dos = Mock(spec=DOS)
+        dos.bandgap = 1.0
+        dos.nelect = 10
+        factory = DefectSystemFactory(
+            defect_species=[ds],
+            dos=dos,
+            volume=1.0,
+            formation_energy_correction_fns=correction_fns_for(cs_a, cs_b),
+        )
+        system = factory.at(300)
+        system.get_sc_fermi = Mock(return_value=[0.5, {}])
+        return system.charge_state_concentration_dict(per_volume=False)["X"]
+
+    def test_factory_correction_fns_accept_name_pairs(self):
+        by_object = self._factory_corrected_x_concentrations(
+            lambda cs_a, cs_b: {cs_a: lambda T: 1e-4 * T}
+        )
+        by_name = self._factory_corrected_x_concentrations(
+            lambda cs_a, cs_b: {("X", "X_a"): lambda T: 1e-4 * T}
+        )
+        self.assertEqual(by_object, by_name)
+
+    def test_factory_correction_fns_unknown_name_raises_at_at(self):
+        cs_a = DefectChargeState(charge=0, energy=1.0, name="X_a")
+        ds = DefectSpecies(name="X", nsites=1, charge_states=[cs_a])
+        dos = Mock(spec=DOS)
+        dos.bandgap = 1.0
+        dos.nelect = 10
+        factory = DefectSystemFactory(
+            defect_species=[ds],
+            dos=dos,
+            volume=1.0,
+            formation_energy_correction_fns={("X", "nope"): lambda T: 0.1},
+        )
+        with self.assertRaisesRegex(ValueError, "available: X_a"):
+            factory.at(300)
+
     def test_repeated_at_calls_are_independent(self):
         factory = DefectSystemFactory(
             defect_species=[self.species],

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -2271,6 +2271,44 @@ class TestDefectSystemBandEdgeCorrections(unittest.TestCase):
                 lambda cs_a, cs_b: {cs_a: 0.2, ("X", "X_a"): 0.1}
             )
 
+    def test_correction_for_fixed_concentration_state_raises(self):
+        # A fixed-concentration state has no formation energy for a
+        # correction to act on; keying it is an input error, not a no-op.
+        cs_var = DefectChargeState(charge=0, energy=1.0, name="X_a")
+        cs_fixed = DefectChargeState(
+            charge=1, fixed_concentration=0.1, name="X_fixed"
+        )
+        ds = DefectSpecies(name="X", nsites=1, charge_states=[cs_var, cs_fixed])
+        dos = Mock(spec=DOS)
+        dos.bandgap = 1.0
+        dos.nelect = 10
+        for key in (cs_fixed, ("X", "X_fixed")):
+            with self.assertRaisesRegex(ValueError, "X_fixed.*cannot be corrected"):
+                DefectSystem(
+                    defect_species=[ds],
+                    volume=1.0,
+                    dos=dos,
+                    temperature=300,
+                    formation_energy_corrections={key: 0.2},
+                )
+
+    def test_invalid_correction_key_shape_raises(self):
+        # A bare string is neither key form and must not be misreported as
+        # an unrecognised DefectChargeState object.
+        cs_a = DefectChargeState(charge=0, energy=1.0, name="X_a")
+        ds = DefectSpecies(name="X", nsites=1, charge_states=[cs_a])
+        dos = Mock(spec=DOS)
+        dos.bandgap = 1.0
+        dos.nelect = 10
+        with self.assertRaisesRegex(ValueError, r"objects or \(species_name"):
+            DefectSystem(
+                defect_species=[ds],
+                volume=1.0,
+                dos=dos,
+                temperature=300,
+                formation_energy_corrections={"X_a": 0.2},
+            )
+
     def test_name_pair_correction_targets_the_right_species(self):
         # Two species each have a default-named "q+0" state; the pair key
         # must correct only the named species' state.


### PR DESCRIPTION
Delivers the corrections decision from #82. `formation_energy_corrections` (`DefectSystem`) and `formation_energy_correction_fns` (`DefectSystemFactory`) now accept keys that identify a charge state either as the `DefectChargeState` object (unchanged) or as a `(species_name, charge_state_name)` pair; the two forms may be mixed.

Pairs are resolved once, at `DefectSystem` construction, through the existing name lookups (`defect_species_by_name` / `charge_state_by_name`), so unknown names fail with the same "available: ..." errors those lookups already produce. Referencing the same charge state through two keys, keying a fixed-concentration state (which has no formation energy for a correction to act on), or passing a key that is neither form raises `ValueError`; the error names the state and its species. Structural validation now runs before correction-key resolution, so a duplicate-species-name error is reported as such rather than surfacing as a confusing resolution failure.

The factory is a pass-through: `at()` already preserves keys when evaluating the correction functions, so its change is annotation and docstring only, and name errors surface at the first `at()` call.

The migration guide's corrections example now leads with the name-pair form and no longer tells the reader to keep a reference to the charge-state object; CHANGELOG and tutorial updated to match.

