### PR TITLE
Name-pair keys for fixed_concentrations; fixing is construction-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@
   `DefectSystemFactory.at(...)`) for a different temperature, DOS, or correction
   set. `occupancy_warning_threshold`, a non-physical reporting preference, stays
   settable and validates on assignment.
+- `DefectChargeState.fix_concentration` and `DefectSpecies.fix_concentration`
+  are no longer public. A concentration is fixed only at construction: via the
+  `fixed_concentration` argument of `DefectChargeState`/`DefectSpecies`, or via
+  `DefectSystem(fixed_concentrations=...)` / `DefectSystemFactory.at(...,
+  fixed_concentrations=...)`. This removes the last route that could mutate a
+  constructed `DefectSystem` in place.
 
 ### Improvements
 
@@ -113,23 +119,21 @@
   names interchangeably (both are normalised to names internally).
   `DefectSystem.defect_species_by_name` now raises a `ValueError` listing the
   available names, rather than an `IndexError`, when given an unknown name.
-- Fixed concentrations are validated at construction. A `ValueError` is raised
-  if a species-level `fixed_concentration` is not a finite, non-negative number
-  (a NaN would otherwise pass silently into the solved concentrations), if a
-  species' individually-fixed charge states are inconsistent with its
-  species-level `fixed_concentration` -- they exceed it, or, when every charge
-  state is fixed so none can absorb a shortfall, fall below it -- or if the
-  total fixed concentration in a site-exclusion group exceeds its available
-  sites (an unpooled species' own `nsites`, or a `site_pools` entry's shared
-  size). These conditions are all independent of the Fermi level; they
-  previously surfaced only at solve time (wrapped as a `RuntimeError` about the
-  Fermi-energy search window) or, for a shortfall, were silently under-reported.
-  They now fail fast at construction with a clear message.
-- `DefectChargeState` validates its `fixed_concentration` at its own boundary:
-  a value that is not finite and non-negative raises `ValueError` from
-  `__init__` and from `fix_concentration`, rather than passing silently into
-  budget sums (where a NaN defeats every comparison and a negative silently
-  reduces the total).
+- The consistency of fixed concentrations is checked at construction. A
+  `ValueError` is raised if a species' individually-fixed charge states are
+  inconsistent with its species-level `fixed_concentration` -- they exceed it,
+  or, when every charge state is fixed so none can absorb a shortfall, fall
+  below it -- or if the total fixed concentration in a site-exclusion group
+  exceeds its available sites (an unpooled species' own `nsites`, or a
+  `site_pools` entry's shared size). These conditions are all independent of the
+  Fermi level; they previously surfaced only at solve time (wrapped as a
+  `RuntimeError` about the Fermi-energy search window) or, for a shortfall, were
+  silently under-reported. They now fail fast at construction with a clear
+  message.
+- `DefectChargeState` and `DefectSpecies` validate their `fixed_concentration`
+  at construction: a value that is not finite and non-negative raises
+  `ValueError`, rather than passing silently into budget sums (where a NaN
+  defeats every comparison and a negative silently reduces the total).
 - Added band-edge corrections (`vbm_shift`, `cbm_shift`,
   `formation_energy_corrections`, `rigid_shift`) to `DefectSystem`. `vbm_shift`
   and `cbm_shift` are pre-evaluated shifts (in eV) that scissor the DOS at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,11 @@
   `DefectChargeState` objects. Referencing the same charge state through two
   keys, keying a fixed-concentration state (which has no formation energy to
   correct), or passing a key that is neither form raises `ValueError`.
+- `fixed_concentrations` (`DefectSystem`, and as a `factory.at()` override)
+  accepts `(species_name, charge_state_name)` pairs as keys, fixing that
+  single charge state at construction, alongside species-name keys for
+  species totals. Charge-state-level quenching no longer requires mutating
+  a constructed system.
 - Added `DefectSystem.charge_state_concentration_dict(per_volume=True)`, which
   returns `{species_name: {charge_state_name: conc}}` with one entry per
   `DefectChargeState`. It returns the same per-species entries as
@@ -151,8 +156,9 @@
   **overrides)` evaluates these functions at `T` and returns an independent
   `DefectSystem`, e.g. `{T: factory.at(T).concentration_dict() for T in
   temperatures}`.
-- `DefectSystem` gained a `fixed_concentrations` argument: a `dict[str, float]`
-  mapping species name to a fixed total concentration per unit cell, applied by
+- `DefectSystem` gained a `fixed_concentrations` argument: a mapping of species
+  name -- or `(species_name, charge_state_name)` pair, fixing that single
+  charge state -- to a fixed concentration per unit cell, applied by
   name to the constructor's own copies of `defect_species` (overriding any
   species-level `fixed_concentration` they were constructed with, and composing
   with `formation_energy_corrections`, keyed by object or by name pair). This

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,11 @@
   previously surfaced only at solve time (wrapped as a `RuntimeError` about the
   Fermi-energy search window) or, for a shortfall, were silently under-reported.
   They now fail fast at construction with a clear message.
+- `DefectChargeState` validates its `fixed_concentration` at its own boundary:
+  a value that is not finite and non-negative raises `ValueError` from
+  `__init__` and from `fix_concentration`, rather than passing silently into
+  budget sums (where a NaN defeats every comparison and a negative silently
+  reduces the total).
 - Added band-edge corrections (`vbm_shift`, `cbm_shift`,
   `formation_energy_corrections`, `rigid_shift`) to `DefectSystem`. `vbm_shift`
   and `cbm_shift` are pre-evaluated shifts (in eV) that scissor the DOS at

--- a/docs/source/migrating_to_v3.rst
+++ b/docs/source/migrating_to_v3.rst
@@ -191,6 +191,17 @@ its charge states re-equilibrate:
     frozen = {name: totals[name] for name in frozen_species}
     quenched = factory.at(quenched_temperature, fixed_concentrations=frozen)
 
+To freeze a single charge state rather than a whole species, key the mapping
+with a ``(species_name, charge_state_name)`` pair; the two key forms can be
+mixed in one mapping. A pair-keyed charge state is held at the given
+concentration while the rest of its species re-equilibrates:
+
+.. code-block:: python
+
+    cs_totals = annealed.charge_state_concentration_dict(per_volume=False)
+    frozen[("V_O", "q+2")] = cs_totals["V_O"]["q+2"]
+    quenched = factory.at(quenched_temperature, fixed_concentrations=frozen)
+
 Temperature-dependent band edges need no special handling here: set
 ``vbm_shift_fn`` and ``cbm_shift_fn`` on the factory (as above) and they are
 evaluated at every snapshot, so the quench gets its own band-edge correction

--- a/docs/source/migrating_to_v3.rst
+++ b/docs/source/migrating_to_v3.rst
@@ -141,6 +141,30 @@ physical system, remains settable.
     # v3: build a new snapshot, e.g. with the factory
     system = factory.at(300)
 
+``fix_concentration`` has been removed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``DefectChargeState.fix_concentration`` and ``DefectSpecies.fix_concentration``
+are no longer public: they were the last route that could mutate a constructed
+``DefectSystem`` in place. A concentration is fixed only at construction. Pass
+``fixed_concentration`` to ``DefectChargeState`` or ``DefectSpecies``, or fix by
+name through ``DefectSystem`` (or ``DefectSystemFactory.at(...)``) with
+``fixed_concentrations``.
+
+.. code-block:: python
+
+    # v2: fix a species (or charge state) after the fact
+    species.fix_concentration(x)
+
+    # v3: fix at construction, by name
+    system = DefectSystem(..., fixed_concentrations={"V_O": x})
+    # or a single charge state
+    system = DefectSystem(..., fixed_concentrations={("V_O", "V_O_2+"): x})
+
+See :ref:`Frozen defects (anneal and quench) <anneal-and-quench>` below for the
+full idiom: solve at the annealing temperature, then re-solve with those values
+held fixed at the quench temperature.
+
 
 New in v3
 ---------
@@ -169,6 +193,8 @@ temperature, evaluated at each snapshot:
     )
 
     results = {T: factory.at(T).concentration_dict() for T in temperatures}
+
+.. _anneal-and-quench:
 
 Frozen defects (anneal and quench)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/tutorial.ipynb
+++ b/docs/source/tutorial.ipynb
@@ -19,10 +19,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T09:30:34.511314Z",
-     "iopub.status.busy": "2026-07-10T09:30:34.511113Z",
-     "iopub.status.idle": "2026-07-10T09:30:34.808740Z",
-     "shell.execute_reply": "2026-07-10T09:30:34.808405Z"
+     "iopub.execute_input": "2026-07-11T20:17:18.455695Z",
+     "iopub.status.busy": "2026-07-11T20:17:18.455470Z",
+     "iopub.status.idle": "2026-07-11T20:17:18.738391Z",
+     "shell.execute_reply": "2026-07-11T20:17:18.738055Z"
     }
    },
    "outputs": [],
@@ -58,10 +58,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T09:30:34.811275Z",
-     "iopub.status.busy": "2026-07-10T09:30:34.811013Z",
-     "iopub.status.idle": "2026-07-10T09:30:34.883360Z",
-     "shell.execute_reply": "2026-07-10T09:30:34.883056Z"
+     "iopub.execute_input": "2026-07-11T20:17:18.740509Z",
+     "iopub.status.busy": "2026-07-11T20:17:18.740338Z",
+     "iopub.status.idle": "2026-07-11T20:17:18.800649Z",
+     "shell.execute_reply": "2026-07-11T20:17:18.800332Z"
     }
    },
    "outputs": [],
@@ -97,10 +97,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T09:30:34.885689Z",
-     "iopub.status.busy": "2026-07-10T09:30:34.885527Z",
-     "iopub.status.idle": "2026-07-10T09:30:37.021532Z",
-     "shell.execute_reply": "2026-07-10T09:30:37.021157Z"
+     "iopub.execute_input": "2026-07-11T20:17:18.802621Z",
+     "iopub.status.busy": "2026-07-11T20:17:18.802505Z",
+     "iopub.status.idle": "2026-07-11T20:17:20.675951Z",
+     "shell.execute_reply": "2026-07-11T20:17:20.675637Z"
     }
    },
    "outputs": [],
@@ -137,10 +137,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T09:30:37.023569Z",
-     "iopub.status.busy": "2026-07-10T09:30:37.023342Z",
-     "iopub.status.idle": "2026-07-10T09:30:37.030024Z",
-     "shell.execute_reply": "2026-07-10T09:30:37.029698Z"
+     "iopub.execute_input": "2026-07-11T20:17:20.678039Z",
+     "iopub.status.busy": "2026-07-11T20:17:20.677825Z",
+     "iopub.status.idle": "2026-07-11T20:17:20.683075Z",
+     "shell.execute_reply": "2026-07-11T20:17:20.682814Z"
     }
    },
    "outputs": [],
@@ -167,10 +167,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T09:30:37.031843Z",
-     "iopub.status.busy": "2026-07-10T09:30:37.031720Z",
-     "iopub.status.idle": "2026-07-10T09:30:37.035049Z",
-     "shell.execute_reply": "2026-07-10T09:30:37.034517Z"
+     "iopub.execute_input": "2026-07-11T20:17:20.684692Z",
+     "iopub.status.busy": "2026-07-11T20:17:20.684579Z",
+     "iopub.status.idle": "2026-07-11T20:17:20.687257Z",
+     "shell.execute_reply": "2026-07-11T20:17:20.686963Z"
     }
    },
    "outputs": [
@@ -217,10 +217,10 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T09:30:37.058083Z",
-     "iopub.status.busy": "2026-07-10T09:30:37.057862Z",
-     "iopub.status.idle": "2026-07-10T09:30:37.060353Z",
-     "shell.execute_reply": "2026-07-10T09:30:37.059833Z"
+     "iopub.execute_input": "2026-07-11T20:17:20.710790Z",
+     "iopub.status.busy": "2026-07-11T20:17:20.710650Z",
+     "iopub.status.idle": "2026-07-11T20:17:20.712661Z",
+     "shell.execute_reply": "2026-07-11T20:17:20.712411Z"
     }
    },
    "outputs": [],
@@ -255,10 +255,10 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T09:30:37.062400Z",
-     "iopub.status.busy": "2026-07-10T09:30:37.062237Z",
-     "iopub.status.idle": "2026-07-10T09:30:37.207221Z",
-     "shell.execute_reply": "2026-07-10T09:30:37.206864Z"
+     "iopub.execute_input": "2026-07-11T20:17:20.714069Z",
+     "iopub.status.busy": "2026-07-11T20:17:20.713961Z",
+     "iopub.status.idle": "2026-07-11T20:17:20.847422Z",
+     "shell.execute_reply": "2026-07-11T20:17:20.847127Z"
     }
    },
    "outputs": [
@@ -318,10 +318,10 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T09:30:37.208879Z",
-     "iopub.status.busy": "2026-07-10T09:30:37.208779Z",
-     "iopub.status.idle": "2026-07-10T09:30:37.787487Z",
-     "shell.execute_reply": "2026-07-10T09:30:37.787148Z"
+     "iopub.execute_input": "2026-07-11T20:17:20.849184Z",
+     "iopub.status.busy": "2026-07-11T20:17:20.849094Z",
+     "iopub.status.idle": "2026-07-11T20:17:21.387226Z",
+     "shell.execute_reply": "2026-07-11T20:17:21.386926Z"
     }
    },
    "outputs": [
@@ -374,10 +374,10 @@
    "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T09:30:37.789282Z",
-     "iopub.status.busy": "2026-07-10T09:30:37.789022Z",
-     "iopub.status.idle": "2026-07-10T09:30:37.950692Z",
-     "shell.execute_reply": "2026-07-10T09:30:37.950289Z"
+     "iopub.execute_input": "2026-07-11T20:17:21.389091Z",
+     "iopub.status.busy": "2026-07-11T20:17:21.388979Z",
+     "iopub.status.idle": "2026-07-11T20:17:21.550745Z",
+     "shell.execute_reply": "2026-07-11T20:17:21.550425Z"
     }
    },
    "outputs": [
@@ -453,10 +453,10 @@
    "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T09:30:37.952944Z",
-     "iopub.status.busy": "2026-07-10T09:30:37.952787Z",
-     "iopub.status.idle": "2026-07-10T09:30:38.094848Z",
-     "shell.execute_reply": "2026-07-10T09:30:38.094489Z"
+     "iopub.execute_input": "2026-07-11T20:17:21.552946Z",
+     "iopub.status.busy": "2026-07-11T20:17:21.552833Z",
+     "iopub.status.idle": "2026-07-11T20:17:21.693334Z",
+     "shell.execute_reply": "2026-07-11T20:17:21.693061Z"
     }
    },
    "outputs": [
@@ -480,16 +480,21 @@
     "# calculate defect and electronic carrier concentrations at high T.\n",
     "live_defect_system = defect_system_factory.at(1500)\n",
     "high_t_defects = live_defect_system.concentration_dict()\n",
+    "high_t_per_cell = live_defect_system.concentration_dict(per_volume=False)\n",
     "\n",
     "# repeat at low T\n",
     "low_t_defect_system = defect_system_factory.at(300)\n",
     "low_t_defects = low_t_defect_system.concentration_dict()\n",
     "\n",
-    "# fix the concentration of the defect species at high T, and then \n",
-    "# calculate the concentration of the electron holes at low T\n",
-    "fixed_species_defect_system = defect_system_factory.at(300)\n",
-    "fixed_species_defect_system.defect_species_by_name(\"v_Na\").fix_concentration(high_t_defects[\"v_Na\"] / 1e24 * defect_system.volume)\n",
-    "fixed_species_defect_system.defect_species_by_name(\"v_Cl\").fix_concentration(high_t_defects[\"v_Cl\"] / 1e24 * defect_system.volume)\n",
+    "# quench: fix the species totals solved at high T, and re-solve the\n",
+    "# electron holes at low T\n",
+    "fixed_species_defect_system = defect_system_factory.at(\n",
+    "    300,\n",
+    "    fixed_concentrations={\n",
+    "        \"v_Na\": high_t_per_cell[\"v_Na\"],\n",
+    "        \"v_Cl\": high_t_per_cell[\"v_Cl\"],\n",
+    "    },\n",
+    ")\n",
     "fixed_species_defects = fixed_species_defect_system.concentration_dict()\n",
     "\n",
     "# plot the results\n",
@@ -515,10 +520,10 @@
    "execution_count": 11,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T09:30:38.096432Z",
-     "iopub.status.busy": "2026-07-10T09:30:38.096299Z",
-     "iopub.status.idle": "2026-07-10T09:30:38.237098Z",
-     "shell.execute_reply": "2026-07-10T09:30:38.236767Z"
+     "iopub.execute_input": "2026-07-11T20:17:21.694845Z",
+     "iopub.status.busy": "2026-07-11T20:17:21.694728Z",
+     "iopub.status.idle": "2026-07-11T20:17:21.826420Z",
+     "shell.execute_reply": "2026-07-11T20:17:21.826169Z"
     }
    },
    "outputs": [
@@ -547,22 +552,16 @@
     "low_t_defect_system = defect_system_factory.at(300)\n",
     "low_t_defects = low_t_defect_system.concentration_dict(decomposed=True)\n",
     "\n",
-    "# fix the concentrations of the individual charge states at high T, and then\n",
-    "# calculate the concentration of the electron holes at low T.\n",
-    "# charge_state_concentration_dict(per_volume=False) gives per-unit-cell\n",
-    "# values keyed by charge-state name (defaulting to the charge string, e.g. \"q-1\").\n",
-    "fixed_species_defect_system = defect_system_factory.at(300)\n",
+    "# quench at the charge-state level: fix the per-state concentrations\n",
+    "# solved at high T, keyed by (species_name, charge_state_name)\n",
     "high_t_cs_concs = live_defect_system.charge_state_concentration_dict(per_volume=False)\n",
-    "\n",
-    "v_Na_minus1_state = fixed_species_defect_system.defect_species_by_name(\n",
-    "    \"v_Na\"\n",
-    ").charge_state_by_name(\"q-1\")\n",
-    "v_Na_minus1_state.fix_concentration(high_t_cs_concs[\"v_Na\"][\"q-1\"])\n",
-    "\n",
-    "v_Cl_plus1_state = fixed_species_defect_system.defect_species_by_name(\n",
-    "    \"v_Cl\"\n",
-    ").charge_state_by_name(\"q+1\")\n",
-    "v_Cl_plus1_state.fix_concentration(high_t_cs_concs[\"v_Cl\"][\"q+1\"])\n",
+    "fixed_species_defect_system = defect_system_factory.at(\n",
+    "    300,\n",
+    "    fixed_concentrations={\n",
+    "        (\"v_Na\", \"q-1\"): high_t_cs_concs[\"v_Na\"][\"q-1\"],\n",
+    "        (\"v_Cl\", \"q+1\"): high_t_cs_concs[\"v_Cl\"][\"q+1\"],\n",
+    "    },\n",
+    ")\n",
     "fixed_species_defects = fixed_species_defect_system.concentration_dict()\n",
     "\n",
     "plt.bar([0, 1, 2],  [high_t_defects[\"p0\"], low_t_defects[\"p0\"], fixed_species_defects[\"p0\"]])\n",
@@ -587,10 +586,10 @@
    "execution_count": 12,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T09:30:38.238949Z",
-     "iopub.status.busy": "2026-07-10T09:30:38.238798Z",
-     "iopub.status.idle": "2026-07-10T09:30:38.693202Z",
-     "shell.execute_reply": "2026-07-10T09:30:38.692801Z"
+     "iopub.execute_input": "2026-07-11T20:17:21.827993Z",
+     "iopub.status.busy": "2026-07-11T20:17:21.827877Z",
+     "iopub.status.idle": "2026-07-11T20:17:22.210457Z",
+     "shell.execute_reply": "2026-07-11T20:17:22.210185Z"
     }
    },
    "outputs": [
@@ -666,10 +665,10 @@
    "execution_count": 13,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T09:30:38.695239Z",
-     "iopub.status.busy": "2026-07-10T09:30:38.695027Z",
-     "iopub.status.idle": "2026-07-10T09:30:38.710239Z",
-     "shell.execute_reply": "2026-07-10T09:30:38.709878Z"
+     "iopub.execute_input": "2026-07-11T20:17:22.212176Z",
+     "iopub.status.busy": "2026-07-11T20:17:22.212057Z",
+     "iopub.status.idle": "2026-07-11T20:17:22.224412Z",
+     "shell.execute_reply": "2026-07-11T20:17:22.224150Z"
     }
    },
    "outputs": [
@@ -685,9 +684,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/np/pvnqvv3958gfjdtbgbbpjqk00000gn/T/ipykernel_58468/2541147710.py:30: DiluteLimitWarning: 'Mg_Na' (50%), 'v_Na' (2.2%) and 'v_Cl' (1.99%) reach high site occupancy at the self-consistent Fermi level. py-sc-fermi assumes dilute, non-interacting defects, so results at this occupancy may be non-physical.\n",
+      "/var/folders/np/pvnqvv3958gfjdtbgbbpjqk00000gn/T/ipykernel_4506/2541147710.py:30: DiluteLimitWarning: 'Mg_Na' (50%), 'v_Na' (2.2%) and 'v_Cl' (1.99%) reach high site occupancy at the self-consistent Fermi level. py-sc-fermi assumes dilute, non-interacting defects, so results at this occupancy may be non-physical.\n",
       "  separate_concs = separate_factory.at(1500).concentration_dict()\n",
-      "/var/folders/np/pvnqvv3958gfjdtbgbbpjqk00000gn/T/ipykernel_58468/2541147710.py:31: DiluteLimitWarning: 'Mg_Na' (50%), 'v_Na' (1.54%) and 'v_Cl' (1.42%) reach high site occupancy at the self-consistent Fermi level. py-sc-fermi assumes dilute, non-interacting defects, so results at this occupancy may be non-physical.\n",
+      "/var/folders/np/pvnqvv3958gfjdtbgbbpjqk00000gn/T/ipykernel_4506/2541147710.py:31: DiluteLimitWarning: 'Mg_Na' (50%), 'v_Na' (1.54%) and 'v_Cl' (1.42%) reach high site occupancy at the self-consistent Fermi level. py-sc-fermi assumes dilute, non-interacting defects, so results at this occupancy may be non-physical.\n",
       "  pool_concs = pool_factory.at(1500).concentration_dict()\n"
      ]
     }
@@ -734,10 +733,10 @@
    "execution_count": 14,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T09:30:38.712039Z",
-     "iopub.status.busy": "2026-07-10T09:30:38.711916Z",
-     "iopub.status.idle": "2026-07-10T09:30:39.596822Z",
-     "shell.execute_reply": "2026-07-10T09:30:39.596543Z"
+     "iopub.execute_input": "2026-07-11T20:17:22.225760Z",
+     "iopub.status.busy": "2026-07-11T20:17:22.225676Z",
+     "iopub.status.idle": "2026-07-11T20:17:23.105909Z",
+     "shell.execute_reply": "2026-07-11T20:17:23.105604Z"
     }
    },
    "outputs": [
@@ -810,10 +809,10 @@
    "execution_count": 15,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T09:30:39.598437Z",
-     "iopub.status.busy": "2026-07-10T09:30:39.598315Z",
-     "iopub.status.idle": "2026-07-10T09:30:39.786614Z",
-     "shell.execute_reply": "2026-07-10T09:30:39.786289Z"
+     "iopub.execute_input": "2026-07-11T20:17:23.107796Z",
+     "iopub.status.busy": "2026-07-11T20:17:23.107686Z",
+     "iopub.status.idle": "2026-07-11T20:17:23.281991Z",
+     "shell.execute_reply": "2026-07-11T20:17:23.281733Z"
     }
    },
    "outputs": [
@@ -912,10 +911,10 @@
    "execution_count": 16,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T09:30:39.788203Z",
-     "iopub.status.busy": "2026-07-10T09:30:39.788081Z",
-     "iopub.status.idle": "2026-07-10T09:30:51.360183Z",
-     "shell.execute_reply": "2026-07-10T09:30:51.359542Z"
+     "iopub.execute_input": "2026-07-11T20:17:23.283464Z",
+     "iopub.status.busy": "2026-07-11T20:17:23.283375Z",
+     "iopub.status.idle": "2026-07-11T20:17:34.480767Z",
+     "shell.execute_reply": "2026-07-11T20:17:34.480374Z"
     }
    },
    "outputs": [
@@ -979,10 +978,10 @@
    "execution_count": 17,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T09:30:51.362560Z",
-     "iopub.status.busy": "2026-07-10T09:30:51.362444Z",
-     "iopub.status.idle": "2026-07-10T09:30:51.365876Z",
-     "shell.execute_reply": "2026-07-10T09:30:51.365582Z"
+     "iopub.execute_input": "2026-07-11T20:17:34.482876Z",
+     "iopub.status.busy": "2026-07-11T20:17:34.482642Z",
+     "iopub.status.idle": "2026-07-11T20:17:34.485693Z",
+     "shell.execute_reply": "2026-07-11T20:17:34.485385Z"
     }
    },
    "outputs": [
@@ -1022,10 +1021,10 @@
    "execution_count": 18,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T09:30:51.367791Z",
-     "iopub.status.busy": "2026-07-10T09:30:51.367646Z",
-     "iopub.status.idle": "2026-07-10T09:30:51.486568Z",
-     "shell.execute_reply": "2026-07-10T09:30:51.486234Z"
+     "iopub.execute_input": "2026-07-11T20:17:34.487319Z",
+     "iopub.status.busy": "2026-07-11T20:17:34.487194Z",
+     "iopub.status.idle": "2026-07-11T20:17:34.605459Z",
+     "shell.execute_reply": "2026-07-11T20:17:34.605177Z"
     }
    },
    "outputs": [
@@ -1076,10 +1075,10 @@
    "execution_count": 19,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T09:30:51.488073Z",
-     "iopub.status.busy": "2026-07-10T09:30:51.487954Z",
-     "iopub.status.idle": "2026-07-10T09:30:51.500074Z",
-     "shell.execute_reply": "2026-07-10T09:30:51.499778Z"
+     "iopub.execute_input": "2026-07-11T20:17:34.607309Z",
+     "iopub.status.busy": "2026-07-11T20:17:34.607199Z",
+     "iopub.status.idle": "2026-07-11T20:17:34.617620Z",
+     "shell.execute_reply": "2026-07-11T20:17:34.617374Z"
     }
    },
    "outputs": [
@@ -1145,10 +1144,10 @@
    "execution_count": 20,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T09:30:51.502487Z",
-     "iopub.status.busy": "2026-07-10T09:30:51.502336Z",
-     "iopub.status.idle": "2026-07-10T09:30:51.504884Z",
-     "shell.execute_reply": "2026-07-10T09:30:51.504580Z"
+     "iopub.execute_input": "2026-07-11T20:17:34.619028Z",
+     "iopub.status.busy": "2026-07-11T20:17:34.618936Z",
+     "iopub.status.idle": "2026-07-11T20:17:34.621104Z",
+     "shell.execute_reply": "2026-07-11T20:17:34.620876Z"
     }
    },
    "outputs": [
@@ -1192,10 +1191,10 @@
    "execution_count": 21,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T09:30:51.506287Z",
-     "iopub.status.busy": "2026-07-10T09:30:51.506179Z",
-     "iopub.status.idle": "2026-07-10T09:30:51.508574Z",
-     "shell.execute_reply": "2026-07-10T09:30:51.508294Z"
+     "iopub.execute_input": "2026-07-11T20:17:34.622418Z",
+     "iopub.status.busy": "2026-07-11T20:17:34.622337Z",
+     "iopub.status.idle": "2026-07-11T20:17:34.624580Z",
+     "shell.execute_reply": "2026-07-11T20:17:34.624347Z"
     }
    },
    "outputs": [
@@ -1243,10 +1242,10 @@
    "execution_count": 22,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T09:30:51.511518Z",
-     "iopub.status.busy": "2026-07-10T09:30:51.511338Z",
-     "iopub.status.idle": "2026-07-10T09:30:51.514053Z",
-     "shell.execute_reply": "2026-07-10T09:30:51.513630Z"
+     "iopub.execute_input": "2026-07-11T20:17:34.625944Z",
+     "iopub.status.busy": "2026-07-11T20:17:34.625866Z",
+     "iopub.status.idle": "2026-07-11T20:17:34.627942Z",
+     "shell.execute_reply": "2026-07-11T20:17:34.627695Z"
     }
    },
    "outputs": [
@@ -1297,10 +1296,10 @@
    "execution_count": 23,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-10T09:30:51.516260Z",
-     "iopub.status.busy": "2026-07-10T09:30:51.516009Z",
-     "iopub.status.idle": "2026-07-10T09:30:52.121740Z",
-     "shell.execute_reply": "2026-07-10T09:30:52.121438Z"
+     "iopub.execute_input": "2026-07-11T20:17:34.629358Z",
+     "iopub.status.busy": "2026-07-11T20:17:34.629276Z",
+     "iopub.status.idle": "2026-07-11T20:17:35.132244Z",
+     "shell.execute_reply": "2026-07-11T20:17:35.131959Z"
     }
    },
    "outputs": [

--- a/py_sc_fermi/defect_charge_state.py
+++ b/py_sc_fermi/defect_charge_state.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import warnings
 from typing import Any
 
@@ -18,7 +19,8 @@ class DefectChargeState:
          charge (int): charge of this ``DefectChargeState``
          degeneracy (float): degeneracy of this charge state
          energy (float): formation energy at E[Fermi] = 0
-         fixed_concentration (float): fixed concentration per unit cell
+         fixed_concentration (float): fixed concentration per unit cell.
+           Must be finite and non-negative.
          name (str | None): identifying label for this charge state, used as
            the key in ``DefectSystem.charge_state_concentration_dict`` and
            ``concentration_dict(decomposed=True)``. Defaults to the charge
@@ -46,8 +48,26 @@ class DefectChargeState:
         self._charge = charge
         self._degeneracy = degeneracy
         self._energy = energy
-        self._fixed_concentration = fixed_concentration
         self._name = name
+        self._fixed_concentration = (
+            self._validated_fixed_concentration(fixed_concentration)
+            if fixed_concentration is not None
+            else None
+        )
+
+    def _validated_fixed_concentration(self, concentration: float) -> float:
+        """Return ``concentration`` if it is a valid fixed concentration.
+
+        Raises:
+            ValueError: if ``concentration`` is not finite and non-negative.
+        """
+        if not math.isfinite(concentration) or concentration < 0:
+            raise ValueError(
+                f"DefectChargeState '{self.name}' has an invalid fixed "
+                f"concentration {concentration}; it must be finite and "
+                "non-negative"
+            )
+        return concentration
 
     @property
     def energy(self) -> float | None:
@@ -165,8 +185,11 @@ class DefectChargeState:
 
         Args:
             concentration (float): ``DefectChargeState`` concentration per unit cell
+
+        Raises:
+            ValueError: if ``concentration`` is not finite and non-negative.
         """
-        self._fixed_concentration = concentration
+        self._fixed_concentration = self._validated_fixed_concentration(concentration)
 
     def get_formation_energy(self, e_fermi: float) -> float:
         """get the formation energy of this ``DefectChargeState`` at a given Fermi

--- a/py_sc_fermi/defect_charge_state.py
+++ b/py_sc_fermi/defect_charge_state.py
@@ -180,8 +180,9 @@ class DefectChargeState:
 
         return defect_dict
 
-    def fix_concentration(self, concentration: float) -> None:
-        """Fixes the concentration (per unit cell) of this ``DefectChargeState``
+    def _fix_concentration(self, concentration: float) -> None:
+        """Set the fixed concentration (per unit cell); internal setter used
+        by construction-time fixing.
 
         Args:
             concentration (float): ``DefectChargeState`` concentration per unit cell

--- a/py_sc_fermi/defect_species.py
+++ b/py_sc_fermi/defect_species.py
@@ -26,6 +26,8 @@ class DefectSpecies:
            represent metastable defect configurations; such states must be
            given explicit, distinct names (charge-state names, including the
            charge-derived defaults, must be unique within a species).
+        fixed_concentration (float | None): fixed total concentration per unit
+           cell. Must be finite and non-negative.
 
     """
 
@@ -59,15 +61,37 @@ class DefectSpecies:
         self._name = name
         self._nsites = nsites
         self._charge_states = charge_states
-        self._fixed_concentration = fixed_concentration
+        self._fixed_concentration = (
+            self._validated_fixed_concentration(fixed_concentration)
+            if fixed_concentration is not None
+            else None
+        )
 
-    def fix_concentration(self, concentration: float) -> None:
-        """fix the concentration of this ``DefectSpecies``
+    def _validated_fixed_concentration(self, concentration: float) -> float:
+        """Return ``concentration`` if it is a valid fixed concentration.
+
+        Raises:
+            ValueError: if ``concentration`` is not finite and non-negative.
+        """
+        if not math.isfinite(concentration) or concentration < 0:
+            raise ValueError(
+                f"DefectSpecies '{self.name}' has an invalid fixed "
+                f"concentration {concentration}; it must be finite and "
+                "non-negative"
+            )
+        return concentration
+
+    def _fix_concentration(self, concentration: float) -> None:
+        """Set the fixed concentration (per unit cell); internal setter used
+        by construction-time fixing.
 
         Args:
             concentration (float): concentration per unit cell
+
+        Raises:
+            ValueError: if ``concentration`` is not finite and non-negative.
         """
-        self._fixed_concentration = concentration
+        self._fixed_concentration = self._validated_fixed_concentration(concentration)
 
     @property
     def name(self) -> str:

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -335,8 +335,9 @@ class DefectSystem:
         state. Both resolve against this system's own copies in
         ``self.defect_species`` (never the caller's originals). The
         concentration values are checked (finite and non-negative) by
-        ``DefectChargeState.fix_concentration`` and, for species totals and
-        their site-exclusion budgets, by ``_validate_fixed_concentrations``.
+        ``DefectChargeState._fix_concentration``/``DefectSpecies._fix_concentration``
+        and, for species totals and their site-exclusion budgets, by
+        ``_validate_fixed_concentrations``.
 
         Raises:
             ValueError: if a key is neither form, a name is not found (via
@@ -347,9 +348,9 @@ class DefectSystem:
             if isinstance(key, tuple) and len(key) == 2:
                 species_name, cs_name = key
                 species = self.defect_species_by_name(species_name)
-                species.charge_state_by_name(cs_name).fix_concentration(conc)
+                species.charge_state_by_name(cs_name)._fix_concentration(conc)
             elif isinstance(key, str):
-                self.defect_species_by_name(key).fix_concentration(conc)
+                self.defect_species_by_name(key)._fix_concentration(conc)
             else:
                 raise ValueError(
                     "fixed_concentrations keys must be a species name or "
@@ -514,16 +515,16 @@ class DefectSystem:
             )
 
     def _validate_fixed_concentrations(self) -> None:
-        """Reject fixed concentrations that are invalid or cannot be hosted.
+        """Reject fixed concentrations that are inconsistent or cannot be hosted.
 
-        The checks are independent of the Fermi level -- they depend only on
-        the fixed concentrations and the site budgets -- so they are static
+        Per-object values are validated at their own boundary, by
+        ``DefectSpecies``/``DefectChargeState`` (at construction, and by their
+        internal ``_fix_concentration`` setters). The checks here are
+        cross-cutting and independent of the Fermi level -- they depend only
+        on the fixed concentrations and the site budgets -- so they are static
         properties of the system, caught here at construction rather than left
         to surface (wrapped as a Fermi-window error) from a later solve:
 
-        * a species-level fixed concentration must be a finite, non-negative
-          number (a NaN would otherwise pass every comparison below and
-          surface silently as ``nan`` in the solved concentrations);
         * a species fixed at the total level must be consistent with its
           individually-fixed charge states: those cannot exceed the total, and
           if every charge state is fixed (none variable) they must sum to it,
@@ -532,21 +533,15 @@ class DefectSystem:
           concentration cannot exceed the group's site budget.
 
         Raises:
-            ValueError: if a species-level fixed concentration is not finite
-                and non-negative, a species' fixed charge states are
-                inconsistent with its species-level fixed concentration, or a
-                group's total fixed concentration exceeds its site budget (its
+            ValueError: if a species' fixed charge states are inconsistent
+                with its species-level fixed concentration, or a group's
+                total fixed concentration exceeds its site budget (its
                 ``site_pools`` size, or, for an unpooled species, its own
                 ``nsites``).
         """
         for sp in self.defect_species:
             if sp.fixed_concentration is None:
                 continue
-            if not math.isfinite(sp.fixed_concentration) or sp.fixed_concentration < 0:
-                raise ValueError(
-                    f"'{sp.name}' has an invalid fixed concentration "
-                    f"{sp.fixed_concentration}; it must be finite and non-negative"
-                )
             charge_state_total = self._charge_state_fixed_total(sp)
             if math.isclose(charge_state_total, sp.fixed_concentration):
                 continue

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -333,26 +333,21 @@ class DefectSystem:
         ``fixed_concentration``, overriding any it was constructed with. A
         ``(species_name, charge_state_name)`` pair fixes that single charge
         state. Both resolve against this system's own copies in
-        ``self.defect_species`` (never the caller's originals) and are
-        validated by ``_validate_fixed_concentrations``.
+        ``self.defect_species`` (never the caller's originals). The
+        concentration values are checked (finite and non-negative) by
+        ``DefectChargeState.fix_concentration`` and, for species totals and
+        their site-exclusion budgets, by ``_validate_fixed_concentrations``.
 
         Raises:
             ValueError: if a key is neither form, a name is not found (via
-                the name lookups, listing the available names), or a
-                pair-keyed value is not finite and non-negative.
+                the name lookups, listing the available names), or a value
+                is not finite and non-negative.
         """
         for key, conc in fixed_concentrations.items():
             if isinstance(key, tuple) and len(key) == 2:
                 species_name, cs_name = key
                 species = self.defect_species_by_name(species_name)
-                cs = species.charge_state_by_name(cs_name)
-                if not math.isfinite(conc) or conc < 0:
-                    raise ValueError(
-                        f"'{cs.name}' of species '{species.name}' has an "
-                        f"invalid fixed concentration {conc}; it must be "
-                        "finite and non-negative"
-                    )
-                cs.fix_concentration(conc)
+                species.charge_state_by_name(cs_name).fix_concentration(conc)
             elif isinstance(key, str):
                 self.defect_species_by_name(key).fix_concentration(conc)
             else:

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -1592,11 +1592,14 @@ class DefectSystemFactory:
             **overrides: keyword arguments forwarded to `DefectSystem.__init__`,
               overriding any of this factory's corresponding attributes (e.g.
               `temperature` itself, or `fixed_concentrations`, a
-              `dict[str, float]` mapping species name to a fixed total
-              concentration per unit cell). Passing `fixed_concentrations`
-              freezes those species' totals at the given values, as in the
-              anneal-and-quench workflow: take the totals solved at a high
-              temperature and re-solve at a lower one with them held fixed.
+              `dict[FixedConcentrationKey, float]` mapping a species name (or a
+              ``(species_name, charge_state_name)`` pair, fixing that single
+              charge state) to a fixed concentration per unit cell). Passing
+              `fixed_concentrations` freezes those species' totals (or
+              per-charge-state values) at the given values, as in the
+              anneal-and-quench workflow: take the totals (or per-charge-state
+              values) solved at a high temperature and re-solve at a lower one
+              with them held fixed.
 
         Returns:
             DefectSystem: a new, independent `DefectSystem` for `temperature`.

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -32,6 +32,11 @@ CorrectionKey = DefectChargeState | tuple[str, str]
 ``(species_name, charge_state_name)`` pair resolved against the system's
 defect species."""
 
+FixedConcentrationKey = str | tuple[str, str]
+"""A fixed-concentration key: a species name (fixes the species' total
+concentration), or a ``(species_name, charge_state_name)`` pair (fixes that
+single charge state)."""
+
 
 class _VariableState(NamedTuple):
     """A non-fixed-concentration charge state within an exclusion group,
@@ -140,16 +145,22 @@ class DefectSystem:
           unchanged. If False, the defect levels are fixed in absolute energy
           while the band edges move, so such charge states have their formation
           energy shifted by `-charge * vbm_shift`.
-        fixed_concentrations (dict[str, float] | None, optional): mapping of
-          species name -> fixed total concentration (per unit cell). Each
-          named species has its total concentration fixed at the given value,
-          overriding any species-level `fixed_concentration` it was constructed
-          with. The fix is applied by name to this system's own copies of
-          `defect_species`, so it composes with `formation_energy_corrections`
-          (resolved against the passed-in `defect_species`) and never
-          mutates the caller's species. A non-finite or negative value, or one
-          that cannot be hosted (above its site-exclusion group's site budget
-          -- its own `nsites`, or its shared `site_pools` size -- or below its
+        fixed_concentrations (dict[FixedConcentrationKey, float] | None, optional):
+          mapping of species name -> fixed total concentration (per unit
+          cell), or ``(species_name, charge_state_name)`` -> fixed
+          concentration for that single charge state. A named species has its
+          total concentration fixed at the given value, overriding any
+          species-level `fixed_concentration` it was constructed with; a
+          `(species_name, charge_state_name)` pair fixes that one charge
+          state, leaving the rest of its species variable. Both forms are
+          applied by name to this system's own copies of `defect_species`, so
+          they compose with `formation_energy_corrections` (resolved against
+          the passed-in `defect_species`) and never mutate the caller's
+          species. A charge state fixed by either key form has its formation
+          energy (including any correction applied to it) left unused by the
+          solve. A non-finite or negative value, or one that cannot be
+          hosted (above its site-exclusion group's site budget -- its own
+          `nsites`, or its shared `site_pools` size -- or below its
           individually-fixed charge states), is rejected at construction by the
           same checks as a species-level fix. Defaults to None (no fixes).
         occupancy_warning_threshold (float | None, optional): the site-occupancy
@@ -169,9 +180,10 @@ class DefectSystem:
           references a species not in `defect_species`, a pool lists a
           species more than once, a species appears in more than one site
           pool, `formation_energy_corrections` references a `DefectChargeState`
-          that is not part of `defect_species`, `fixed_concentrations` names
-          a species not in `defect_species`, or `occupancy_warning_threshold`
-          is not ``None`` or a finite fraction in (0, 1].
+          that is not part of `defect_species`, a `fixed_concentrations` key
+          names a species (or, for a pair key, a charge state) not in
+          `defect_species`, or `occupancy_warning_threshold` is not ``None``
+          or a finite fraction in (0, 1].
 
     Note:
         `DefectSystem` is a fixed-temperature snapshot whose physical public
@@ -199,7 +211,7 @@ class DefectSystem:
         cbm_shift: float = 0.0,
         formation_energy_corrections: dict[CorrectionKey, float] | None = None,
         rigid_shift: bool = True,
-        fixed_concentrations: dict[str, float] | None = None,
+        fixed_concentrations: dict[FixedConcentrationKey, float] | None = None,
         occupancy_warning_threshold: float | None = 0.01,
     ):
         self._volume = volume
@@ -313,22 +325,41 @@ class DefectSystem:
         return value
 
     def _apply_fixed_concentrations(
-        self, fixed_concentrations: dict[str, float]
+        self, fixed_concentrations: dict[FixedConcentrationKey, float]
     ) -> None:
-        """Fix the total concentration of named species on the deep copies.
+        """Fix concentrations on the deep copies, by name.
 
-        Each ``name -> conc`` entry sets the species-level
-        ``fixed_concentration`` of the matching copy in ``self.defect_species``,
-        overriding any species-level fix it was constructed with. The copies
-        are resolved by name (never the caller's originals) and validated by
-        ``_validate_fixed_concentrations``.
+        A ``str`` key names a species and sets its species-level
+        ``fixed_concentration``, overriding any it was constructed with. A
+        ``(species_name, charge_state_name)`` pair fixes that single charge
+        state. Both resolve against this system's own copies in
+        ``self.defect_species`` (never the caller's originals) and are
+        validated by ``_validate_fixed_concentrations``.
 
         Raises:
-            ValueError: if a name is not in the species roster (via
-                ``defect_species_by_name``, listing the available names).
+            ValueError: if a key is neither form, a name is not found (via
+                the name lookups, listing the available names), or a
+                pair-keyed value is not finite and non-negative.
         """
-        for name, conc in fixed_concentrations.items():
-            self.defect_species_by_name(name).fix_concentration(conc)
+        for key, conc in fixed_concentrations.items():
+            if isinstance(key, tuple) and len(key) == 2:
+                species_name, cs_name = key
+                species = self.defect_species_by_name(species_name)
+                cs = species.charge_state_by_name(cs_name)
+                if not math.isfinite(conc) or conc < 0:
+                    raise ValueError(
+                        f"'{cs.name}' of species '{species.name}' has an "
+                        f"invalid fixed concentration {conc}; it must be "
+                        "finite and non-negative"
+                    )
+                cs.fix_concentration(conc)
+            elif isinstance(key, str):
+                self.defect_species_by_name(key).fix_concentration(conc)
+            else:
+                raise ValueError(
+                    "fixed_concentrations keys must be a species name or "
+                    f"(species_name, charge_state_name) pair; got {key!r}."
+                )
 
     @staticmethod
     def _resolve_correction_keys(

--- a/tests/test_defect_charge_state.py
+++ b/tests/test_defect_charge_state.py
@@ -41,13 +41,13 @@ class TestDefectChargeStateInit(unittest.TestCase):
         cs = DefectChargeState(charge=1, fixed_concentration=0.0)
         self.assertEqual(cs.fixed_concentration, 0.0)
 
-    def test_fix_concentration_rejects_invalid_values(self):
+    def test__fix_concentration_rejects_invalid_values(self):
         cs = DefectChargeState(charge=1, energy=1.0, name="X_a")
         for bad in (-0.1, float("nan"), float("inf")):
             with self.assertRaisesRegex(
                 ValueError, r"'X_a'.*finite and non-negative"
             ):
-                cs.fix_concentration(bad)
+                cs._fix_concentration(bad)
         self.assertIsNone(cs.fixed_concentration)
 
 
@@ -105,9 +105,9 @@ class TestDefectChargeStateFixConcentration(unittest.TestCase):
             charge=charge, energy=energy, degeneracy=degeneracy
         )
 
-    def test_fix_concentration(self):
+    def test__fix_concentration(self):
         self.assertEqual(self.defect_charge_state.fixed_concentration, None)
-        self.defect_charge_state.fix_concentration(1)
+        self.defect_charge_state._fix_concentration(1)
         self.assertEqual(self.defect_charge_state.fixed_concentration, 1)
 
 
@@ -151,10 +151,10 @@ class TestDefectChargeStateGetConcentration(unittest.TestCase):
     def test_get_concentration_with_fixed_concentration(self):
         e_fermi = 1.2
         temperature = 298.0
-        self.defect_charge_state.fix_concentration(1.0)
-        conc = self.defect_charge_state.get_concentration(
-            e_fermi=e_fermi, temperature=temperature
+        cs = DefectChargeState(
+            charge=1, energy=0.1234, degeneracy=2, fixed_concentration=1.0
         )
+        conc = cs.get_concentration(e_fermi=e_fermi, temperature=temperature)
         self.assertEqual(conc, 1.0)
 
 
@@ -194,16 +194,20 @@ class TestDefectChargeStateDictionaryOperations(unittest.TestCase):
         self.assertEqual(dictionary["charge"], 1)
 
     def test_defect_system_as_dict_fixed_concentration(self):
-        self.defect_charge_state.fix_concentration(1)
-        dictionary = self.defect_charge_state.as_dict()
+        cs = DefectChargeState(charge=1, energy=0.1234, degeneracy=2, fixed_concentration=1)
+        dictionary = cs.as_dict()
         self.assertEqual(dictionary["degeneracy"], 2)
         self.assertEqual(dictionary["energy"], 0.1234)
         self.assertEqual(dictionary["charge"], 1)
         self.assertEqual(dictionary["fixed_concentration"], 1)
 
     def test_as_dict_emits_native_floats_for_numpy_values(self):
-        cs = DefectChargeState(charge=1, energy=np.float64(0.5), degeneracy=2)
-        cs.fix_concentration(np.float64(1e20))
+        cs = DefectChargeState(
+            charge=1,
+            energy=np.float64(0.5),
+            degeneracy=2,
+            fixed_concentration=np.float64(1e20),
+        )
         dictionary = cs.as_dict()
         self.assertIs(type(dictionary["energy"]), float)
         self.assertIs(type(dictionary["fixed_concentration"]), float)
@@ -253,8 +257,9 @@ class TestDefectChargeStateDictionaryOperations(unittest.TestCase):
         self.assertEqual(cs.name, "q+1")
 
     def test_round_trip_preserves_energy_of_fixed_concentration_state(self):
-        cs = DefectChargeState(charge=1, energy=0.7, degeneracy=1, name="V_O_frozen")
-        cs.fix_concentration(0.01)
+        cs = DefectChargeState(
+            charge=1, energy=0.7, degeneracy=1, fixed_concentration=0.01, name="V_O_frozen"
+        )
         reloaded = DefectChargeState.from_dict(cs.as_dict())
         self.assertEqual(reloaded.energy, 0.7)
         self.assertEqual(reloaded.fixed_concentration, 0.01)

--- a/tests/test_defect_charge_state.py
+++ b/tests/test_defect_charge_state.py
@@ -30,6 +30,26 @@ class TestDefectChargeStateInit(unittest.TestCase):
         with self.assertRaises(ValueError):
             DefectChargeState(charge=1, energy=0.5, degeneracy=-1)
 
+    def test_init_rejects_invalid_fixed_concentration(self):
+        for bad in (-0.1, float("nan"), float("inf")):
+            with self.assertRaisesRegex(
+                ValueError, r"'q\+1'.*finite and non-negative"
+            ):
+                DefectChargeState(charge=1, fixed_concentration=bad)
+
+    def test_init_accepts_zero_fixed_concentration(self):
+        cs = DefectChargeState(charge=1, fixed_concentration=0.0)
+        self.assertEqual(cs.fixed_concentration, 0.0)
+
+    def test_fix_concentration_rejects_invalid_values(self):
+        cs = DefectChargeState(charge=1, energy=1.0, name="X_a")
+        for bad in (-0.1, float("nan"), float("inf")):
+            with self.assertRaisesRegex(
+                ValueError, r"'X_a'.*finite and non-negative"
+            ):
+                cs.fix_concentration(bad)
+        self.assertIsNone(cs.fixed_concentration)
+
 
 class TestDefectChargeStateChargeProperty(unittest.TestCase):
     def setUp(self):

--- a/tests/test_defect_species.py
+++ b/tests/test_defect_species.py
@@ -130,6 +130,23 @@ class TestDefectSpeciesInit(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "q\\+1"):
             DefectSpecies.from_dict(d)
 
+    def test_init_rejects_invalid_fixed_concentration(self):
+        for bad in (-0.1, float("nan"), float("inf")):
+            with self.assertRaisesRegex(ValueError, r"'V_O'.*finite and non-negative"):
+                DefectSpecies(
+                    "V_O", nsites=1,
+                    charge_states=[DefectChargeState(charge=0, energy=1.0)],
+                    fixed_concentration=bad,
+                )
+
+    def test_init_accepts_zero_fixed_concentration(self):
+        species = DefectSpecies(
+            "V_O", nsites=1,
+            charge_states=[DefectChargeState(charge=0, energy=1.0)],
+            fixed_concentration=0.0,
+        )
+        self.assertEqual(species.fixed_concentration, 0.0)
+
 
 class TestDefectSpecies(unittest.TestCase):
     def setUp(self):
@@ -165,9 +182,9 @@ class TestDefectSpecies(unittest.TestCase):
             self.defect_species._fixed_concentration,
         )
 
-    def test_fix_concentration(self):
+    def test__fix_concentration(self):
         self.assertEqual(self.defect_species.fixed_concentration, None)
-        self.defect_species.fix_concentration(0.1234)
+        self.defect_species._fix_concentration(0.1234)
         self.assertEqual(self.defect_species.fixed_concentration, 0.1234)
 
     def test_charge_states_by_formation_energy(self):
@@ -378,7 +395,7 @@ class TestDefectSpecies(unittest.TestCase):
         )
 
     def test_charge_states_and_defect_species_have_fixed_concentration(self):
-        self.defect_species.fix_concentration(concentration=0.1234*3)
+        self.defect_species._fix_concentration(concentration=0.1234*3)
         for cs in self.defect_species.charge_states:
             cs.fixed_concentration = 0.1234
             cs.get_concentration = Mock(return_value=0.1234)
@@ -606,9 +623,9 @@ class TestDefectSpecies(unittest.TestCase):
         defect = DefectSpecies(
             name="v_Na",
             nsites=1,
-            charge_states=[cs_0, cs_minus1]
+            charge_states=[cs_0, cs_minus1],
+            fixed_concentration=1e-5,
         )
-        defect.fix_concentration(1e-5)
 
         result = defect.charge_state_concentrations(e_fermi=0.0, temperature=300)
 
@@ -627,9 +644,9 @@ class TestDefectSpecies(unittest.TestCase):
         defect = DefectSpecies(
             name="test",
             nsites=1,
-            charge_states=[cs_0, cs_1]
+            charge_states=[cs_0, cs_1],
+            fixed_concentration=0.1,  # Less than fixed charge state concentration
         )
-        defect.fix_concentration(0.1)  # Less than fixed charge state concentration
 
         with self.assertRaises(ValueError):
             defect.charge_state_concentrations(e_fermi=0.0, temperature=298)
@@ -639,8 +656,9 @@ class TestDefectSpecies(unittest.TestCase):
         less than the species total, with no variable state to make up the
         difference."""
         cs_0 = DefectChargeState(charge=0, fixed_concentration=3.0)
-        defect = DefectSpecies(name="test", nsites=10, charge_states=[cs_0])
-        defect.fix_concentration(5.0)
+        defect = DefectSpecies(
+            name="test", nsites=10, charge_states=[cs_0], fixed_concentration=5.0
+        )
 
         with self.assertRaises(ValueError):
             defect.charge_state_concentrations(e_fermi=0.0, temperature=298)

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -804,9 +804,11 @@ class TestDefectSystemSitePools(unittest.TestCase):
             self._two_state_system({0: 0.1})
 
     def test_pair_key_with_invalid_value_raises(self):
+        # The value check lives on DefectChargeState.fix_concentration, which
+        # the pair path calls; its message names the charge state.
         for bad in (-0.1, float("nan"), float("inf")):
             with self.assertRaisesRegex(
-                ValueError, r"'X_a' of species 'X'.*finite and non-negative"
+                ValueError, r"'X_a'.*finite and non-negative"
             ):
                 self._two_state_system({("X", "X_a"): bad})
 

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -560,7 +560,7 @@ class TestDefectSystemSitePools(unittest.TestCase):
     def test_pool_raises_when_fixed_concentrations_exceed_site_count(self):
         # Over-budget fixed concentrations are a static constraint violation,
         # rejected at construction rather than surfacing from the solve.
-        self.species_a.charge_states[0].fix_concentration(20.0)
+        self.species_a.charge_states[0]._fix_concentration(20.0)
         with self.assertRaises(ValueError):
             DefectSystem(
                 defect_species=[self.species_a],
@@ -571,7 +571,7 @@ class TestDefectSystemSitePools(unittest.TestCase):
             )
 
     def test_pooled_species_honours_species_level_fixed_concentration(self):
-        self.species_a.fix_concentration(3.0)
+        self.species_a._fix_concentration(3.0)
         no_pool_system = DefectSystem(
             defect_species=[self.species_a],
             dos=self.dos,
@@ -599,7 +599,7 @@ class TestDefectSystemSitePools(unittest.TestCase):
     def test_pool_raises_when_species_level_fixed_concentration_exceeds_site_count(
         self,
     ):
-        self.species_a.fix_concentration(20.0)
+        self.species_a._fix_concentration(20.0)
         with self.assertRaises(ValueError):
             DefectSystem(
                 defect_species=[self.species_a],
@@ -612,7 +612,7 @@ class TestDefectSystemSitePools(unittest.TestCase):
     def test_unpooled_species_raises_when_fixed_concentration_exceeds_nsites(self):
         # An unpooled species' implicit group budget is its own nsites; the
         # error names the species and the budget-versus-occupancy.
-        self.species_a.fix_concentration(20.0)  # nsites=5
+        self.species_a._fix_concentration(20.0)  # nsites=5
         with self.assertRaisesRegex(ValueError, r"'A' has 5 .*occupy 20"):
             DefectSystem(
                 defect_species=[self.species_a],
@@ -664,9 +664,9 @@ class TestDefectSystemSitePools(unittest.TestCase):
     def test_pool_raises_when_members_jointly_exceed_site_count(self):
         # Each member fits the pool alone -- A across its two fixed charge
         # states, B in one -- but together they exceed the shared budget.
-        self.species_a.charge_states[0].fix_concentration(4.0)
-        self.species_a.charge_states[1].fix_concentration(4.0)
-        self.species_b.charge_states[0].fix_concentration(4.0)
+        self.species_a.charge_states[0]._fix_concentration(4.0)
+        self.species_a.charge_states[1]._fix_concentration(4.0)
+        self.species_b.charge_states[0]._fix_concentration(4.0)
         with self.assertRaises(ValueError):
             DefectSystem(
                 defect_species=[self.species_a, self.species_b],
@@ -752,21 +752,31 @@ class TestDefectSystemSitePools(unittest.TestCase):
         # species total remains variable: only the one state is fixed
         self.assertIsNone(system.defect_species_by_name("X").fixed_concentration)
 
-    def test_pair_key_matches_post_construction_fixing(self):
-        # The constructor route must solve identically to the (legacy)
-        # in-place mutation route.
-        by_constructor = self._two_state_system({("X", "X_a"): 0.25})
-        by_constructor.get_sc_fermi = Mock(return_value=[0.5, {}])
-        constructed = by_constructor.charge_state_concentration_dict(per_volume=False)
+    def test_pair_key_matches_direct_fixed_construction(self):
+        # The pair-key route must solve identically to constructing the same
+        # charge state directly fixed.
+        by_pair_key = self._two_state_system({("X", "X_a"): 0.25})
+        by_pair_key.get_sc_fermi = Mock(return_value=[0.5, {}])
+        via_pair_key = by_pair_key.charge_state_concentration_dict(per_volume=False)
 
-        mutated_system = self._two_state_system(None)
-        mutated_system.defect_species_by_name("X").charge_state_by_name(
-            "X_a"
-        ).fix_concentration(0.25)
-        mutated_system.get_sc_fermi = Mock(return_value=[0.5, {}])
-        mutated = mutated_system.charge_state_concentration_dict(per_volume=False)
+        cs_a = DefectChargeState(charge=0, energy=1.0, name="X_a", fixed_concentration=0.25)
+        cs_b = DefectChargeState(charge=1, energy=1.5, name="X_b")
+        ds = DefectSpecies(name="X", nsites=1, charge_states=[cs_a, cs_b])
+        dos = Mock(spec=DOS)
+        dos.bandgap = 1.0
+        dos.nelect = 10
+        by_direct_construction = DefectSystem(
+            defect_species=[ds],
+            volume=1.0,
+            dos=dos,
+            temperature=300,
+        )
+        by_direct_construction.get_sc_fermi = Mock(return_value=[0.5, {}])
+        via_direct_construction = by_direct_construction.charge_state_concentration_dict(
+            per_volume=False
+        )
 
-        self.assertEqual(constructed, mutated)
+        self.assertEqual(via_pair_key, via_direct_construction)
 
     def test_species_and_pair_keys_mix(self):
         cs_a = DefectChargeState(charge=0, energy=1.0, name="X_a")
@@ -804,7 +814,7 @@ class TestDefectSystemSitePools(unittest.TestCase):
             self._two_state_system({0: 0.1})
 
     def test_pair_key_with_invalid_value_raises(self):
-        # The value check lives on DefectChargeState.fix_concentration, which
+        # The value check lives on DefectChargeState._fix_concentration, which
         # the pair path calls; its message names the charge state.
         for bad in (-0.1, float("nan"), float("inf")):
             with self.assertRaisesRegex(
@@ -1204,7 +1214,7 @@ class TestDefectSystemElementPools(unittest.TestCase):
 
     def test_element_pool_leaves_fixed_charge_states_unscaled(self):
         fixed_value = 2.0
-        self.species.charge_states[0].fix_concentration(fixed_value)
+        self.species.charge_states[0]._fix_concentration(fixed_value)
         target = 5.0
         system = DefectSystem(
             defect_species=[self.species],
@@ -1219,7 +1229,7 @@ class TestDefectSystemElementPools(unittest.TestCase):
         self.assertAlmostEqual(total_mg, target, places=6)
 
     def test_element_pool_raises_when_fixed_states_exceed_target(self):
-        self.species.charge_states[0].fix_concentration(10.0)
+        self.species.charge_states[0]._fix_concentration(10.0)
         system = DefectSystem(
             defect_species=[self.species],
             dos=self.dos,

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -2954,6 +2954,22 @@ class TestDefectSystemFixedConcentrations(unittest.TestCase):
         )
         self.assertEqual(system.defect_species_by_name("X").fixed_concentration, 0.01)
 
+    def test_at_fixed_concentrations_accepts_pair_keys(self):
+        cs_a = DefectChargeState(charge=0, energy=1.0, name="X_a")
+        cs_b = DefectChargeState(charge=1, energy=1.5, name="X_b")
+        ds = DefectSpecies(name="X", nsites=1, charge_states=[cs_a, cs_b])
+        dos = Mock(spec=DOS)
+        dos.bandgap = 1.0
+        dos.nelect = 10
+        factory = DefectSystemFactory(defect_species=[ds], dos=dos, volume=1.0)
+        system = factory.at(300, fixed_concentrations={("X", "X_a"): 0.25})
+        self.assertEqual(
+            system.defect_species_by_name("X")
+            .charge_state_by_name("X_a")
+            .fixed_concentration,
+            0.25,
+        )
+
     def test_anneal_and_quench_freezes_some_species_and_re_equilibrates_rest(self):
         # A minority donor frozen at its high-temperature total, plus a major
         # donor/acceptor pair that re-equilibrates when the temperature drops.

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -728,6 +728,88 @@ class TestDefectSystemSitePools(unittest.TestCase):
         )
         self.assertAlmostEqual(total, 0.3, places=8)
 
+    def _two_state_system(self, fixed_concentrations):
+        cs_a = DefectChargeState(charge=0, energy=1.0, name="X_a")
+        cs_b = DefectChargeState(charge=1, energy=1.5, name="X_b")
+        ds = DefectSpecies(name="X", nsites=1, charge_states=[cs_a, cs_b])
+        dos = Mock(spec=DOS)
+        dos.bandgap = 1.0
+        dos.nelect = 10
+        return DefectSystem(
+            defect_species=[ds],
+            volume=1.0,
+            dos=dos,
+            temperature=300,
+            fixed_concentrations=fixed_concentrations,
+        )
+
+    def test_pair_key_fixes_one_charge_state(self):
+        system = self._two_state_system({("X", "X_a"): 0.25})
+        fixed_state = system.defect_species_by_name("X").charge_state_by_name("X_a")
+        free_state = system.defect_species_by_name("X").charge_state_by_name("X_b")
+        self.assertEqual(fixed_state.fixed_concentration, 0.25)
+        self.assertIsNone(free_state.fixed_concentration)
+        # species total remains variable: only the one state is fixed
+        self.assertIsNone(system.defect_species_by_name("X").fixed_concentration)
+
+    def test_pair_key_matches_post_construction_fixing(self):
+        # The constructor route must solve identically to the (legacy)
+        # in-place mutation route.
+        by_constructor = self._two_state_system({("X", "X_a"): 0.25})
+        by_constructor.get_sc_fermi = Mock(return_value=[0.5, {}])
+        constructed = by_constructor.charge_state_concentration_dict(per_volume=False)
+
+        mutated_system = self._two_state_system(None)
+        mutated_system.defect_species_by_name("X").charge_state_by_name(
+            "X_a"
+        ).fix_concentration(0.25)
+        mutated_system.get_sc_fermi = Mock(return_value=[0.5, {}])
+        mutated = mutated_system.charge_state_concentration_dict(per_volume=False)
+
+        self.assertEqual(constructed, mutated)
+
+    def test_species_and_pair_keys_mix(self):
+        cs_a = DefectChargeState(charge=0, energy=1.0, name="X_a")
+        cs_y = DefectChargeState(charge=0, energy=1.2, name="Y_a")
+        ds_x = DefectSpecies(name="X", nsites=1, charge_states=[cs_a])
+        ds_y = DefectSpecies(name="Y", nsites=1, charge_states=[cs_y])
+        dos = Mock(spec=DOS)
+        dos.bandgap = 1.0
+        dos.nelect = 10
+        system = DefectSystem(
+            defect_species=[ds_x, ds_y],
+            volume=1.0,
+            dos=dos,
+            temperature=300,
+            fixed_concentrations={"X": 0.5, ("Y", "Y_a"): 0.1},
+        )
+        self.assertEqual(system.defect_species_by_name("X").fixed_concentration, 0.5)
+        self.assertEqual(
+            system.defect_species_by_name("Y")
+            .charge_state_by_name("Y_a")
+            .fixed_concentration,
+            0.1,
+        )
+
+    def test_pair_key_with_unknown_charge_state_raises(self):
+        with self.assertRaisesRegex(ValueError, "available: X_a, X_b"):
+            self._two_state_system({("X", "nope"): 0.1})
+
+    def test_pair_key_with_unknown_species_raises(self):
+        with self.assertRaisesRegex(ValueError, "no defect species named 'Z'"):
+            self._two_state_system({("Z", "X_a"): 0.1})
+
+    def test_invalid_fixed_concentration_key_shape_raises(self):
+        with self.assertRaisesRegex(ValueError, r"species name or \(species_name"):
+            self._two_state_system({0: 0.1})
+
+    def test_pair_key_with_invalid_value_raises(self):
+        for bad in (-0.1, float("nan"), float("inf")):
+            with self.assertRaisesRegex(
+                ValueError, r"'X_a' of species 'X'.*finite and non-negative"
+            ):
+                self._two_state_system({("X", "X_a"): bad})
+
     def test_species_fixed_above_fixed_charge_states_with_variable_succeeds(self):
         # With a variable charge state to absorb the remainder, a species
         # total above its fixed charge states is fine.


### PR DESCRIPTION
Fixing a defect concentration is now a construction-time operation only, and the ways to do it are unified around name keys.

`fixed_concentrations` (on `DefectSystem`, and as a `factory.at()` override) accepts keys that are either a species name (fixing the species' total, as before) or a `(species_name, charge_state_name)` pair (fixing that single charge state); the two forms may be mixed. Pair keys resolve through the existing name lookups, so unknown names fail with the same "available: ..." errors.

This gives charge-state-level quenching a constructor route: the tutorial's anneal-and-quench cells now pass `fixed_concentrations` to `factory.at()` instead of mutating a constructed system, with bit-identical solved results.

**Breaking:** `DefectChargeState.fix_concentration` and `DefectSpecies.fix_concentration` are no longer public — they were the last route that could mutate a *constructed* `DefectSystem` in place (`defect_species_by_name`/`charge_state_by_name` return the system's live internal objects), and no documented workflow used them any more. A concentration is fixed only at construction: via the `fixed_concentration` argument of `DefectChargeState`/`DefectSpecies`, or via `DefectSystem` / `factory.at` `fixed_concentrations`. `DefectSystem` is now immutable through every public route, which unblocks the unconditionally-cached result object planned in #86.

Both `DefectChargeState` and `DefectSpecies` now validate their `fixed_concentration` (finite, non-negative) at their own boundary, closing a pre-existing gap where a NaN or negative value passed silently into the site-budget sums. `_validate_fixed_concentrations` keeps only the cross-object checks (species-total-vs-charge-states consistency, site budgets).

A charge state fixed by either key form has its formation energy (including any correction applied to it) left unused by the solve; this is disclosed in the constructor docstring rather than guarded, since a factory's correction functions legitimately coexist with quench fixes.

Migration guide and CHANGELOG updated.
