### PR TITLE
Replace flat-dict read-outs with a cached DefectSystem.result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,8 @@
   any of them after construction raises `AttributeError`, enforcing the
   documented immutable-snapshot contract. Construct a new `DefectSystem` (or use
   `DefectSystemFactory.at(...)`) for a different temperature, DOS, or correction
-  set. `occupancy_warning_threshold`, a non-physical reporting preference, stays
-  settable and validates on assignment.
+  set. `occupancy_warning_threshold`, a non-physical reporting preference, is
+  likewise set only at construction, validated there and read-only thereafter.
 - `DefectChargeState.fix_concentration` and `DefectSpecies.fix_concentration`
   are no longer public. A concentration is fixed only at construction: via the
   `fixed_concentration` argument of `DefectChargeState`/`DefectSpecies`, or via

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,18 +23,20 @@
   `convergence_tolerance` to control solver precision instead.
 - `DefectSpecies` names within a `DefectSystem` must now be unique;
   constructing a `DefectSystem` with two species sharing a name raises a
-  `ValueError`. Names key `concentration_dict` and `defect_species_by_name`, so
-  duplicates were already ambiguous -- this now fails loudly at construction
-  rather than silently.
-- `concentration_dict(decomposed=True)` now keys the inner dict by charge-state
-  name rather than charge integer, with one entry per `DefectChargeState`.
-  `DefectChargeState.name` defaults to the charge string (`"q+2"`, `"q-1"`,
-  `"q+0"`); metastable states sharing a formal charge must be given explicit
-  names, and duplicate names within a species raise `ValueError` at
-  construction. Previously, states sharing a formal charge were summed into a
-  single entry. Code that indexed the old dict by charge integer
-  (e.g. `result["V_O"][2]`) must be updated to use the name
-  (e.g. `result["V_O"]["q+2"]`, or `result["V_O"]["V_O_2+"]` for a named state).
+  `ValueError`. Names key `defect_species_by_name` and the per-species entries
+  in `DefectSystem.result`, so duplicates were already ambiguous -- this now
+  fails loudly at construction rather than silently.
+- `DefectSystem.result.charge_state_concentrations` keys the inner dict by
+  charge-state name rather than charge integer, with one entry per
+  `DefectChargeState`. `DefectChargeState.name` defaults to the charge string
+  (`"q+2"`, `"q-1"`, `"q+0"`); metastable states sharing a formal charge must
+  be given explicit names, and duplicate names within a species raise
+  `ValueError` at construction. Previously the per-charge-state read-out was
+  keyed by charge integer and summed states sharing a formal charge into a
+  single entry. Code that indexed the old dict by charge integer (e.g.
+  `d["V_O"][2]`) must use the name (e.g.
+  `system.result.charge_state_concentrations["V_O"]["q+2"]`, or
+  `["V_O"]["V_O_2+"]` for a named state).
 - `DefectSystem`'s physical public attributes (`volume`, `dos`, `temperature`,
   `convergence_tolerance`, `vbm_shift`, `cbm_shift`, `rigid_shift`,
   `defect_species`, `site_pools`, `element_pools`) are now read-only; rebinding
@@ -49,15 +51,25 @@
   `DefectSystem(fixed_concentrations=...)` / `DefectSystemFactory.at(...,
   fixed_concentrations=...)`. This removes the last route that could mutate a
   constructed `DefectSystem` in place.
+- `DefectSystem.report()`, `concentration_dict()` and
+  `charge_state_concentration_dict()` have been removed. A solved system is now
+  read through a single cached `DefectSystem.result` (a `DefectSystemResult`):
+  `result.concentrations` and `result.charge_state_concentrations` give the
+  per-species and per-charge-state concentrations in cm^-3, with
+  `concentrations_per_cell` / `charge_state_concentrations_per_cell`
+  counterparts; `result.fermi_energy`, `result.p0` and `result.n0` are the
+  solved scalars; `print(result)` gives the human-readable report and
+  `result.as_dict()` a JSON-safe record. The `decomposed` and `per_volume`
+  flags are gone, and `as_dict` uses snake_case keys (`fermi_energy`, not
+  `"Fermi Energy"`).
 
 ### Improvements
 
 - `DefectChargeState` has a `name` attribute, used as the key in
-  `concentration_dict(decomposed=True)` and
-  `charge_state_concentration_dict()`. It defaults to the charge string
-  (`"q+2"`); explicit names are required for metastable states sharing a
-  formal charge, and must be unique within a species. Explicit names appear
-  in `__repr__` and round-trip through `as_dict` / `from_dict`.
+  `DefectSystem.result.charge_state_concentrations`. It defaults to the charge
+  string (`"q+2"`); explicit names are required for metastable states sharing a
+  formal charge, and must be unique within a species. Explicit names appear in
+  `__repr__` and round-trip through `as_dict` / `from_dict`.
 - Added `DefectSpecies.charge_state_by_name`, mirroring
   `DefectSystem.defect_species_by_name`; raises `ValueError` listing the
   available names when no charge state matches.
@@ -72,11 +84,6 @@
   single charge state at construction, alongside species-name keys for
   species totals. Charge-state-level quenching no longer requires mutating
   a constructed system.
-- Added `DefectSystem.charge_state_concentration_dict(per_volume=True)`, which
-  returns `{species_name: {charge_state_name: conc}}` with one entry per
-  `DefectChargeState`. It returns the same per-species entries as
-  `concentration_dict(decomposed=True)`, without the
-  `"Fermi Energy"`/`"p0"`/`"n0"` metadata.
 - `DefectSpecies.get_formation_energies`, `get_transition_level_and_energy`,
   and `tl_profile` now correctly support multiple `DefectChargeState`s sharing
   a formal charge (metastable defects, see above): each charge is represented
@@ -141,8 +148,8 @@
   by `cbm_shift - vbm_shift` (the VBM is pinned at E=0), which changes the
   carrier concentrations from the Fermi-Dirac integration and the
   self-consistent Fermi level, as well as the effective band gap shown by
-  `__repr__`/`report`. The new `DOS.scissored(delta_gap)` performs this shift
-  and returns a new `DOS`. `formation_energy_corrections` is a
+  `__repr__`. The new `DOS.scissored(delta_gap)` performs this shift and
+  returns a new `DOS`. `formation_energy_corrections` is a
   `dict` of per-charge-state formation-energy corrections, keyed by the
   `DefectChargeState` object or a `(species_name, charge_state_name)` pair,
   so that metastable states sharing a formal charge can be corrected
@@ -155,16 +162,15 @@
   is an immutable, fixed-temperature snapshot:
   corrections are applied once at construction to copies of `defect_species`
   (and to a private scissored DOS), the caller's objects are never modified,
-  and `report()`/`as_dict()`/`from_dict()` always agree.
+  and `as_dict()`/`from_dict()` and the solved `result` always agree.
 - Added `DefectSystemFactory`, for building `DefectSystem` snapshots at a
   series of temperatures from temperature-dependent `vbm_shift_fn`,
   `cbm_shift_fn` and `formation_energy_correction_fns` (each a function of
   temperature; the latter a `dict` of temperature-dependent formation-energy
   corrections keyed per charge state, e.g. vibrational free-energy
-  contributions). `factory.at(T,
-  **overrides)` evaluates these functions at `T` and returns an independent
-  `DefectSystem`, e.g. `{T: factory.at(T).concentration_dict() for T in
-  temperatures}`.
+  contributions). `factory.at(T, **overrides)` evaluates these functions at `T`
+  and returns an independent `DefectSystem`, e.g. `{T:
+  factory.at(T).result.concentrations for T in temperatures}`.
 - `DefectSystem` gained a `fixed_concentrations` argument: a mapping of species
   name -- or `(species_name, charge_state_name)` pair, fixing that single
   charge state -- to a fixed concentration per unit cell, applied by
@@ -195,20 +201,30 @@
   defined. A target above an element's unconstrained content gives a positive
   shift, below it a negative shift, and equal to it a near-zero shift. The
   shift is re-derived from the same element-pool solve used for the
-  concentrations, so it is consistent with `concentration_dict`; an element
-  driven to the complete-exclusion limit is reported as `-inf`. Intended for
-  external stability-region checks (py-sc-fermi has no competing-phase data).
+  concentrations, so it is consistent with the concentrations in `result`; an
+  element driven to the complete-exclusion limit is reported as `-inf`.
+  Intended for external stability-region checks (py-sc-fermi has no
+  competing-phase data).
+- Added `DefectSystem.result`, a cached `DefectSystemResult` holding the solved
+  self-consistent Fermi level, carrier concentrations, and per-species and
+  per-charge-state defect concentrations. Concentrations are exposed in cm^-3
+  (the default) and per unit cell, with per-species totals derived from the
+  per-charge-state breakdown so the two cannot disagree; `str(result)` is the
+  human-readable report and `result.as_dict()` a JSON-safe record. The system
+  solves once on first access and caches the result (it is an immutable
+  snapshot). `DefectSystem` and `DefectSystemFactory` also gained an optional
+  `label`, a human-readable tag copied into `result` and serialised when set.
 
 ### Bug Fixes
 
 - `DefectSystem.site_percentages` is now computed from the solved,
   site-exclusion- and pool-aware concentrations (`_global_defect_concs` at
   the self-consistent Fermi level) rather than the unbounded dilute
-  Boltzmann expression. A near-saturation or pooled species previously
-  reported occupancies far above 100%, contradicting the concentrations from
-  `report` and `concentration_dict`; each species' occupancy is now divided
-  by the sites available to it (its own `nsites`, or the shared `site_pools`
-  size for a pooled species), so every reported occupancy is at most 100%.
+  Boltzmann expression. A near-saturation or pooled species previously reported
+  occupancies far above 100%, contradicting the concentrations in `result`;
+  each species' occupancy is now divided by the sites available to it (its own
+  `nsites`, or the shared `site_pools` size for a pooled species), so every
+  reported occupancy is at most 100%.
 
 ## V2.2.2
 

--- a/docs/source/migrating_to_v3.rst
+++ b/docs/source/migrating_to_v3.rst
@@ -70,30 +70,57 @@ Because the charge states form an ordered collection, a single species may now
 hold several states with the same formal charge, which is how v3 represents
 metastable defects.
 
-``concentration_dict(decomposed=True)`` keys by string, not charge
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The flat-dict read-outs have been replaced by ``DefectSystem.result``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The inner dict returned by ``concentration_dict(decomposed=True)`` previously
-mapped formal charge (``int``) to concentration. It now maps the charge state's
-``name`` to concentration, with one entry per ``DefectChargeState`` rather than
-one per formal charge. ``name`` defaults to the charge string (``"q+2"``);
-metastable states sharing a formal charge must be given explicit names (two
-states with the same name raise ``ValueError`` when the ``DefectSpecies`` is
-built).
+``DefectSystem.report()``, ``concentration_dict()`` and
+``charge_state_concentration_dict()`` have been removed. A solved system is now
+read through a single cached ``DefectSystem.result`` object, whose
+concentrations are in cm^-3 by default with per-unit-cell counterparts also
+available.
+
+.. list-table::
+   :header-rows: 1
+
+   * - v2
+     - v3
+   * - ``system.report()``
+     - ``print(system.result)``
+   * - ``system.concentration_dict()``
+     - ``system.result.concentrations``
+   * - ``system.concentration_dict(per_volume=False)``
+     - ``system.result.concentrations_per_cell``
+   * - ``system.concentration_dict(decomposed=True)``
+     - ``system.result.charge_state_concentrations``
+   * - ``system.charge_state_concentration_dict()``
+     - ``system.result.charge_state_concentrations``
+
+``result.as_dict()`` returns the same information in a JSON-safe record; its
+scalar keys are snake_case (``fermi_energy``, ``p0``, ``n0``), where v2's
+``concentration_dict()`` used ``"Fermi Energy"``.
+
+``result.charge_state_concentrations`` keys by name, not charge
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In v2, ``concentration_dict(decomposed=True)`` mapped formal charge (``int``)
+to concentration. ``result.charge_state_concentrations`` instead maps the
+charge state's ``name`` to concentration, with one entry per
+``DefectChargeState`` rather than one per formal charge. ``name`` defaults to
+the charge string (``"q+2"``); metastable states sharing a formal charge must
+be given explicit names (two states with the same name raise ``ValueError``
+when the ``DefectSpecies`` is built).
 
 .. code-block:: python
 
-    # v2 / old v3
-    conc_2plus = result["V_O"][2]
+    # v2
+    decomposed = system.concentration_dict(decomposed=True)
+    conc_2plus = decomposed["V_O"][2]
 
     # v3: default name
-    conc_2plus = result["V_O"]["q+2"]
+    conc_2plus = system.result.charge_state_concentrations["V_O"]["q+2"]
 
     # v3: explicit name
-    conc_2plus = result["V_O"]["V_O_2+"]
-
-The new ``DefectSystem.charge_state_concentration_dict()`` method uses the same
-keys and is the recommended way to retrieve per-charge-state concentrations.
+    conc_2plus = system.result.charge_state_concentrations["V_O"]["V_O_2+"]
 
 The legacy SC-Fermi input format has been removed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -117,9 +144,9 @@ Defect species names must be unique
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A ``DefectSystem`` raises ``ValueError`` if two ``DefectSpecies`` share a name.
-Names key ``concentration_dict`` and ``defect_species_by_name``, so duplicate
-names were already ambiguous; this now fails at construction rather than
-silently. Give each species a distinct name.
+Names key ``defect_species_by_name`` and the per-species entries in
+``DefectSystem.result``, so duplicate names were already ambiguous; this now
+fails at construction rather than silently. Give each species a distinct name.
 
 ``DefectSystem`` attributes are read-only
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -192,7 +219,7 @@ temperature, evaluated at each snapshot:
         cbm_shift_fn=lambda T: ...,
     )
 
-    results = {T: factory.at(T).concentration_dict() for T in temperatures}
+    results = {T: factory.at(T).result for T in temperatures}
 
 .. _anneal-and-quench:
 
@@ -211,7 +238,7 @@ its charge states re-equilibrate:
 
     # equilibrium at the annealing temperature
     annealed = factory.at(annealing_temperature)
-    totals = annealed.concentration_dict(per_volume=False)   # per unit cell
+    totals = annealed.result.concentrations_per_cell
 
     # quench: freeze chosen species' totals, re-solve at the lower temperature
     frozen = {name: totals[name] for name in frozen_species}
@@ -224,7 +251,7 @@ concentration while the rest of its species re-equilibrates:
 
 .. code-block:: python
 
-    cs_totals = annealed.charge_state_concentration_dict(per_volume=False)
+    cs_totals = annealed.result.charge_state_concentrations_per_cell
     frozen[("V_O", "q+2")] = cs_totals["V_O"]["q+2"]
     quenched = factory.at(quenched_temperature, fixed_concentrations=frozen)
 
@@ -267,7 +294,7 @@ calculations:
         },
     )
 
-    results = {T: factory.at(T).concentration_dict() for T in temperatures}
+    results = {T: factory.at(T).result for T in temperatures}
 
 At each temperature the correction is re-evaluated and baked into the formation
 energy before the self-consistent Fermi level is solved. ``DefectSystem``
@@ -282,13 +309,7 @@ Also new
 - Metastable charge states, and Boltzmann-weighted effective formation energies
   for charges with more than one form.
 - ``DefectChargeState`` has a ``name``, used as the key in
-  ``concentration_dict(decomposed=True)`` and
-  ``charge_state_concentration_dict()``; it defaults to the charge string
+  ``result.charge_state_concentrations``; it defaults to the charge string
   (``"q+2"``), and explicit names distinguish metastable states.
-- ``DefectSystem.charge_state_concentration_dict(per_volume=True)`` returns
-  ``{species_name: {charge_state_name: conc}}``, one entry per
-  ``DefectChargeState`` — the same per-species entries as
-  ``concentration_dict(decomposed=True)``, without the
-  ``"Fermi Energy"``/``"p0"``/``"n0"`` metadata.
 - Site pools (a shared site budget across several species) and element pools (a
   target content for an element, solved through its chemical potential).

--- a/docs/source/migrating_to_v3.rst
+++ b/docs/source/migrating_to_v3.rst
@@ -131,7 +131,7 @@ raises ``AttributeError``. To compute at a different temperature, DOS, or
 correction set, construct a new ``DefectSystem``, or use
 ``DefectSystemFactory.at(...)``, which builds one snapshot per temperature.
 ``occupancy_warning_threshold``, a reporting preference rather than part of the
-physical system, remains settable.
+physical system, is likewise set only at construction.
 
 .. code-block:: python
 

--- a/docs/source/tutorial.ipynb
+++ b/docs/source/tutorial.ipynb
@@ -19,10 +19,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:17:18.455695Z",
-     "iopub.status.busy": "2026-07-11T20:17:18.455470Z",
-     "iopub.status.idle": "2026-07-11T20:17:18.738391Z",
-     "shell.execute_reply": "2026-07-11T20:17:18.738055Z"
+     "iopub.execute_input": "2026-07-13T14:38:17.967212Z",
+     "iopub.status.busy": "2026-07-13T14:38:17.966948Z",
+     "iopub.status.idle": "2026-07-13T14:38:18.277414Z",
+     "shell.execute_reply": "2026-07-13T14:38:18.277047Z"
     }
    },
    "outputs": [],
@@ -58,10 +58,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:17:18.740509Z",
-     "iopub.status.busy": "2026-07-11T20:17:18.740338Z",
-     "iopub.status.idle": "2026-07-11T20:17:18.800649Z",
-     "shell.execute_reply": "2026-07-11T20:17:18.800332Z"
+     "iopub.execute_input": "2026-07-13T14:38:18.279195Z",
+     "iopub.status.busy": "2026-07-13T14:38:18.279049Z",
+     "iopub.status.idle": "2026-07-13T14:38:18.343362Z",
+     "shell.execute_reply": "2026-07-13T14:38:18.343057Z"
     }
    },
    "outputs": [],
@@ -97,10 +97,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:17:18.802621Z",
-     "iopub.status.busy": "2026-07-11T20:17:18.802505Z",
-     "iopub.status.idle": "2026-07-11T20:17:20.675951Z",
-     "shell.execute_reply": "2026-07-11T20:17:20.675637Z"
+     "iopub.execute_input": "2026-07-13T14:38:18.345203Z",
+     "iopub.status.busy": "2026-07-13T14:38:18.345093Z",
+     "iopub.status.idle": "2026-07-13T14:38:20.876678Z",
+     "shell.execute_reply": "2026-07-13T14:38:20.876332Z"
     }
    },
    "outputs": [],
@@ -137,10 +137,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:17:20.678039Z",
-     "iopub.status.busy": "2026-07-11T20:17:20.677825Z",
-     "iopub.status.idle": "2026-07-11T20:17:20.683075Z",
-     "shell.execute_reply": "2026-07-11T20:17:20.682814Z"
+     "iopub.execute_input": "2026-07-13T14:38:20.878403Z",
+     "iopub.status.busy": "2026-07-13T14:38:20.878215Z",
+     "iopub.status.idle": "2026-07-13T14:38:20.887612Z",
+     "shell.execute_reply": "2026-07-13T14:38:20.887356Z"
     }
    },
    "outputs": [],
@@ -158,8 +158,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`defect_system.report()` will print a summary of the solved defect system\n",
-    "including the the defect concentrations and the self-consistent Fermi energy"
+    "Printing `defect_system.result` gives a summary of the solved system: the\n",
+    "self-consistent Fermi energy, the electron and hole concentrations, and the\n",
+    "equilibrium defect concentrations broken down by charge state."
    ]
   },
   {
@@ -167,38 +168,35 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:17:20.684692Z",
-     "iopub.status.busy": "2026-07-11T20:17:20.684579Z",
-     "iopub.status.idle": "2026-07-11T20:17:20.687257Z",
-     "shell.execute_reply": "2026-07-11T20:17:20.686963Z"
+     "iopub.execute_input": "2026-07-13T14:38:20.889429Z",
+     "iopub.status.busy": "2026-07-13T14:38:20.889284Z",
+     "iopub.status.idle": "2026-07-13T14:38:20.897499Z",
+     "shell.execute_reply": "2026-07-13T14:38:20.897193Z"
     }
    },
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "DefectSystem\n",
-       "  bandgap:     5 eV    nelect: 20\n",
-       "  volume:      46.1 Å³    temperature: 500 K\n",
-       "\n",
-       "  2 defect species:\n",
-       "\n",
-       "  v_Na  [nsites: 1]\n",
-       "    q = +0   E =   1.0000 eV  (deg. 1)\n",
-       "    q = -1   E =   2.0000 eV  (deg. 1)\n",
-       "\n",
-       "  v_Cl  [nsites: 1]\n",
-       "    q = +0   E =   1.0000 eV  (deg. 1)\n",
-       "    q = +1   E =  -1.0000 eV  (deg. 1)"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SC Fermi energy:  1.500000 eV\n",
+      "\n",
+      "Carriers:\n",
+      "  p0 (holes):     1.138e+06 cm⁻³\n",
+      "  n0 (electrons): 3.921e-18 cm⁻³\n",
+      "\n",
+      "Defect concentrations:\n",
+      "  v_Na              1.979e+17 cm⁻³\n",
+      "    q+0      1.806e+12 cm⁻³  (  0.00%)\n",
+      "    q-1      1.979e+17 cm⁻³  (100.00%)\n",
+      "  v_Cl              1.979e+17 cm⁻³\n",
+      "    q+0      1.806e+12 cm⁻³  (  0.00%)\n",
+      "    q+1      1.979e+17 cm⁻³  (100.00%)\n"
+     ]
     }
    ],
    "source": [
-    "defect_system"
+    "print(defect_system.result)"
    ]
   },
   {
@@ -217,10 +215,10 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:17:20.710790Z",
-     "iopub.status.busy": "2026-07-11T20:17:20.710650Z",
-     "iopub.status.idle": "2026-07-11T20:17:20.712661Z",
-     "shell.execute_reply": "2026-07-11T20:17:20.712411Z"
+     "iopub.execute_input": "2026-07-13T14:38:20.920474Z",
+     "iopub.status.busy": "2026-07-13T14:38:20.920317Z",
+     "iopub.status.idle": "2026-07-13T14:38:20.922257Z",
+     "shell.execute_reply": "2026-07-13T14:38:20.922012Z"
     }
    },
    "outputs": [],
@@ -255,10 +253,10 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:17:20.714069Z",
-     "iopub.status.busy": "2026-07-11T20:17:20.713961Z",
-     "iopub.status.idle": "2026-07-11T20:17:20.847422Z",
-     "shell.execute_reply": "2026-07-11T20:17:20.847127Z"
+     "iopub.execute_input": "2026-07-13T14:38:20.923617Z",
+     "iopub.status.busy": "2026-07-13T14:38:20.923518Z",
+     "iopub.status.idle": "2026-07-13T14:38:21.050704Z",
+     "shell.execute_reply": "2026-07-13T14:38:21.050426Z"
     }
    },
    "outputs": [
@@ -318,10 +316,10 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:17:20.849184Z",
-     "iopub.status.busy": "2026-07-11T20:17:20.849094Z",
-     "iopub.status.idle": "2026-07-11T20:17:21.387226Z",
-     "shell.execute_reply": "2026-07-11T20:17:21.386926Z"
+     "iopub.execute_input": "2026-07-13T14:38:21.052172Z",
+     "iopub.status.busy": "2026-07-13T14:38:21.052081Z",
+     "iopub.status.idle": "2026-07-13T14:38:21.619448Z",
+     "shell.execute_reply": "2026-07-13T14:38:21.619123Z"
     }
    },
    "outputs": [
@@ -348,7 +346,7 @@
     "v_Na_conc = []\n",
     "\n",
     "for t in temperatures:\n",
-    "    concentrations = defect_system_factory.at(t).concentration_dict()\n",
+    "    concentrations = defect_system_factory.at(t).result.concentrations\n",
     "    v_Cl_conc.append(concentrations[\"v_Cl\"])\n",
     "    v_Na_conc.append(concentrations[\"v_Na\"])\n",
     "\n",
@@ -374,10 +372,10 @@
    "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:17:21.389091Z",
-     "iopub.status.busy": "2026-07-11T20:17:21.388979Z",
-     "iopub.status.idle": "2026-07-11T20:17:21.550745Z",
-     "shell.execute_reply": "2026-07-11T20:17:21.550425Z"
+     "iopub.execute_input": "2026-07-13T14:38:21.621251Z",
+     "iopub.status.busy": "2026-07-13T14:38:21.621132Z",
+     "iopub.status.idle": "2026-07-13T14:38:21.788592Z",
+     "shell.execute_reply": "2026-07-13T14:38:21.788331Z"
     }
    },
    "outputs": [
@@ -453,10 +451,10 @@
    "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:17:21.552946Z",
-     "iopub.status.busy": "2026-07-11T20:17:21.552833Z",
-     "iopub.status.idle": "2026-07-11T20:17:21.693334Z",
-     "shell.execute_reply": "2026-07-11T20:17:21.693061Z"
+     "iopub.execute_input": "2026-07-13T14:38:21.790202Z",
+     "iopub.status.busy": "2026-07-13T14:38:21.790078Z",
+     "iopub.status.idle": "2026-07-13T14:38:21.928134Z",
+     "shell.execute_reply": "2026-07-13T14:38:21.927829Z"
     }
    },
    "outputs": [
@@ -479,26 +477,26 @@
    "source": [
     "# calculate defect and electronic carrier concentrations at high T.\n",
     "live_defect_system = defect_system_factory.at(1500)\n",
-    "high_t_defects = live_defect_system.concentration_dict()\n",
-    "high_t_per_cell = live_defect_system.concentration_dict(per_volume=False)\n",
+    "high_t = live_defect_system.result\n",
     "\n",
     "# repeat at low T\n",
     "low_t_defect_system = defect_system_factory.at(300)\n",
-    "low_t_defects = low_t_defect_system.concentration_dict()\n",
+    "low_t = low_t_defect_system.result\n",
     "\n",
     "# quench: fix the species totals solved at high T, and re-solve the\n",
     "# electron holes at low T\n",
+    "high_t_concs = high_t.concentrations_per_cell\n",
     "fixed_species_defect_system = defect_system_factory.at(\n",
     "    300,\n",
     "    fixed_concentrations={\n",
-    "        \"v_Na\": high_t_per_cell[\"v_Na\"],\n",
-    "        \"v_Cl\": high_t_per_cell[\"v_Cl\"],\n",
+    "        \"v_Na\": high_t_concs[\"v_Na\"],\n",
+    "        \"v_Cl\": high_t_concs[\"v_Cl\"],\n",
     "    },\n",
     ")\n",
-    "fixed_species_defects = fixed_species_defect_system.concentration_dict()\n",
+    "fixed_species = fixed_species_defect_system.result\n",
     "\n",
     "# plot the results\n",
-    "plt.bar([0, 1, 2],  [high_t_defects[\"p0\"], low_t_defects[\"p0\"], fixed_species_defects[\"p0\"]])\n",
+    "plt.bar([0, 1, 2],  [high_t.p0, low_t.p0, fixed_species.p0])\n",
     "plt.xticks([0, 1, 2], [\"high T\", \"low T\", \"fixed species\"])\n",
     "plt.ylabel(\"Concentration / cm^-3\")\n",
     "plt.yscale(\"log\")"
@@ -520,10 +518,10 @@
    "execution_count": 11,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:17:21.694845Z",
-     "iopub.status.busy": "2026-07-11T20:17:21.694728Z",
-     "iopub.status.idle": "2026-07-11T20:17:21.826420Z",
-     "shell.execute_reply": "2026-07-11T20:17:21.826169Z"
+     "iopub.execute_input": "2026-07-13T14:38:21.930022Z",
+     "iopub.status.busy": "2026-07-13T14:38:21.929886Z",
+     "iopub.status.idle": "2026-07-13T14:38:22.065345Z",
+     "shell.execute_reply": "2026-07-13T14:38:22.065079Z"
     }
    },
    "outputs": [
@@ -546,15 +544,15 @@
    "source": [
     "# calculate defect and electronic carrier concentrations at high T.\n",
     "live_defect_system = defect_system_factory.at(1500)\n",
-    "high_t_defects = live_defect_system.concentration_dict(decomposed=True)\n",
+    "high_t = live_defect_system.result\n",
     "\n",
     "# repeat at low T\n",
     "low_t_defect_system = defect_system_factory.at(300)\n",
-    "low_t_defects = low_t_defect_system.concentration_dict(decomposed=True)\n",
+    "low_t = low_t_defect_system.result\n",
     "\n",
     "# quench at the charge-state level: fix the per-state concentrations\n",
     "# solved at high T, keyed by (species_name, charge_state_name)\n",
-    "high_t_cs_concs = live_defect_system.charge_state_concentration_dict(per_volume=False)\n",
+    "high_t_cs_concs = high_t.charge_state_concentrations_per_cell\n",
     "fixed_species_defect_system = defect_system_factory.at(\n",
     "    300,\n",
     "    fixed_concentrations={\n",
@@ -562,9 +560,9 @@
     "        (\"v_Cl\", \"q+1\"): high_t_cs_concs[\"v_Cl\"][\"q+1\"],\n",
     "    },\n",
     ")\n",
-    "fixed_species_defects = fixed_species_defect_system.concentration_dict()\n",
+    "fixed_species = fixed_species_defect_system.result\n",
     "\n",
-    "plt.bar([0, 1, 2],  [high_t_defects[\"p0\"], low_t_defects[\"p0\"], fixed_species_defects[\"p0\"]])\n",
+    "plt.bar([0, 1, 2],  [high_t.p0, low_t.p0, fixed_species.p0])\n",
     "plt.xticks([0, 1, 2], [\"high T\", \"low T\", \"fixed charge states\"])\n",
     "plt.ylabel(\"Concentration / cm^-3\")\n",
     "plt.yscale(\"log\")"
@@ -586,10 +584,10 @@
    "execution_count": 12,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:17:21.827993Z",
-     "iopub.status.busy": "2026-07-11T20:17:21.827877Z",
-     "iopub.status.idle": "2026-07-11T20:17:22.210457Z",
-     "shell.execute_reply": "2026-07-11T20:17:22.210185Z"
+     "iopub.execute_input": "2026-07-13T14:38:22.066792Z",
+     "iopub.status.busy": "2026-07-13T14:38:22.066682Z",
+     "iopub.status.idle": "2026-07-13T14:38:22.477050Z",
+     "shell.execute_reply": "2026-07-13T14:38:22.476593Z"
     }
    },
    "outputs": [
@@ -621,11 +619,11 @@
     "    dopant_species = DefectSpecies(\"dopant\", 1, charge_states = [dopant_charge_state])\n",
     "    live_defect_system = DefectSystem(defect_species = [dopant_species,\n",
     "                                                        v_Na, v_Cl], volume = defect_system.volume, temperature = 500, dos = defect_system.dos)\n",
-    "    defect_data = live_defect_system.concentration_dict()\n",
-    "    v_Na_conc.append(defect_data[\"v_Na\"])\n",
-    "    v_Cl_conc.append(defect_data[\"v_Cl\"])\n",
-    "    p_0.append(defect_data[\"p0\"])\n",
-    "    n_0.append(defect_data[\"n0\"])\n",
+    "    result = live_defect_system.result\n",
+    "    v_Na_conc.append(result.concentrations[\"v_Na\"])\n",
+    "    v_Cl_conc.append(result.concentrations[\"v_Cl\"])\n",
+    "    p_0.append(result.p0)\n",
+    "    n_0.append(result.n0)\n",
     "\n",
     "plt.plot(dopant_concentrations, v_Na_conc, label=r\"$V_\\mathrm{Na}$\")\n",
     "plt.plot(dopant_concentrations, v_Cl_conc, label=r\"$V_\\mathrm{Cl}$\")\n",
@@ -665,10 +663,10 @@
    "execution_count": 13,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:17:22.212176Z",
-     "iopub.status.busy": "2026-07-11T20:17:22.212057Z",
-     "iopub.status.idle": "2026-07-11T20:17:22.224412Z",
-     "shell.execute_reply": "2026-07-11T20:17:22.224150Z"
+     "iopub.execute_input": "2026-07-13T14:38:22.478710Z",
+     "iopub.status.busy": "2026-07-13T14:38:22.478582Z",
+     "iopub.status.idle": "2026-07-13T14:38:22.492926Z",
+     "shell.execute_reply": "2026-07-13T14:38:22.492576Z"
     }
    },
    "outputs": [
@@ -684,10 +682,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/np/pvnqvv3958gfjdtbgbbpjqk00000gn/T/ipykernel_4506/2541147710.py:30: DiluteLimitWarning: 'Mg_Na' (50%), 'v_Na' (2.2%) and 'v_Cl' (1.99%) reach high site occupancy at the self-consistent Fermi level. py-sc-fermi assumes dilute, non-interacting defects, so results at this occupancy may be non-physical.\n",
-      "  separate_concs = separate_factory.at(1500).concentration_dict()\n",
-      "/var/folders/np/pvnqvv3958gfjdtbgbbpjqk00000gn/T/ipykernel_4506/2541147710.py:31: DiluteLimitWarning: 'Mg_Na' (50%), 'v_Na' (1.54%) and 'v_Cl' (1.42%) reach high site occupancy at the self-consistent Fermi level. py-sc-fermi assumes dilute, non-interacting defects, so results at this occupancy may be non-physical.\n",
-      "  pool_concs = pool_factory.at(1500).concentration_dict()\n"
+      "/var/folders/np/pvnqvv3958gfjdtbgbbpjqk00000gn/T/ipykernel_95624/4273524033.py:30: DiluteLimitWarning: 'Mg_Na' (50%), 'v_Na' (2.2%) and 'v_Cl' (1.99%) reach high site occupancy at the self-consistent Fermi level. py-sc-fermi assumes dilute, non-interacting defects, so results at this occupancy may be non-physical.\n",
+      "  separate_concs = separate_factory.at(1500).result.concentrations\n",
+      "/var/folders/np/pvnqvv3958gfjdtbgbbpjqk00000gn/T/ipykernel_95624/4273524033.py:31: DiluteLimitWarning: 'Mg_Na' (50%), 'v_Na' (1.54%) and 'v_Cl' (1.42%) reach high site occupancy at the self-consistent Fermi level. py-sc-fermi assumes dilute, non-interacting defects, so results at this occupancy may be non-physical.\n",
+      "  pool_concs = pool_factory.at(1500).result.concentrations\n"
      ]
     }
    ],
@@ -721,8 +719,8 @@
     "\n",
     "# Mg_Na_fixed sits at 50% occupancy, so each solve below emits a DiluteLimitWarning\n",
     "# (see the markdown above) — that high occupancy is the point of this demonstration.\n",
-    "separate_concs = separate_factory.at(1500).concentration_dict()\n",
-    "pool_concs = pool_factory.at(1500).concentration_dict()\n",
+    "separate_concs = separate_factory.at(1500).result.concentrations\n",
+    "pool_concs = pool_factory.at(1500).result.concentrations\n",
     "\n",
     "print(f\"[v_Na], own site budget:    {separate_concs['v_Na']:.3e} cm⁻³\")\n",
     "print(f\"[v_Na], shared with Mg_Na:  {pool_concs['v_Na']:.3e} cm⁻³\")"
@@ -733,10 +731,10 @@
    "execution_count": 14,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:17:22.225760Z",
-     "iopub.status.busy": "2026-07-11T20:17:22.225676Z",
-     "iopub.status.idle": "2026-07-11T20:17:23.105909Z",
-     "shell.execute_reply": "2026-07-11T20:17:23.105604Z"
+     "iopub.execute_input": "2026-07-13T14:38:22.494551Z",
+     "iopub.status.busy": "2026-07-13T14:38:22.494441Z",
+     "iopub.status.idle": "2026-07-13T14:38:23.370099Z",
+     "shell.execute_reply": "2026-07-13T14:38:23.369703Z"
     }
    },
    "outputs": [
@@ -771,8 +769,8 @@
     "with warnings.catch_warnings():\n",
     "    warnings.simplefilter(\"ignore\", DiluteLimitWarning)\n",
     "    for t in temperatures:\n",
-    "        separate_v_Na.append(separate_factory.at(t).concentration_dict()[\"v_Na\"])\n",
-    "        pool_v_Na.append(pool_factory.at(t).concentration_dict()[\"v_Na\"])\n",
+    "        separate_v_Na.append(separate_factory.at(t).result.concentrations[\"v_Na\"])\n",
+    "        pool_v_Na.append(pool_factory.at(t).result.concentrations[\"v_Na\"])\n",
     "\n",
     "plt.plot(temperatures, separate_v_Na, label=r\"$v_\\mathrm{Na}$, own site budget\")\n",
     "plt.plot(temperatures, pool_v_Na, label=r\"$v_\\mathrm{Na}$, shared with $\\mathrm{Mg}_\\mathrm{Na}$\", ls=\"--\")\n",
@@ -809,10 +807,10 @@
    "execution_count": 15,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:17:23.107796Z",
-     "iopub.status.busy": "2026-07-11T20:17:23.107686Z",
-     "iopub.status.idle": "2026-07-11T20:17:23.281991Z",
-     "shell.execute_reply": "2026-07-11T20:17:23.281733Z"
+     "iopub.execute_input": "2026-07-13T14:38:23.372235Z",
+     "iopub.status.busy": "2026-07-13T14:38:23.372099Z",
+     "iopub.status.idle": "2026-07-13T14:38:23.563492Z",
+     "shell.execute_reply": "2026-07-13T14:38:23.563219Z"
     }
    },
    "outputs": [
@@ -896,8 +894,8 @@
     "print()\n",
     "\n",
     "scale = 1e24 / 46.10\n",
-    "free_cd  = free_system.concentration_dict()\n",
-    "elem_cd  = elem_system.concentration_dict()\n",
+    "free_cd  = free_system.result.concentrations\n",
+    "elem_cd  = elem_system.result.concentrations\n",
     "\n",
     "print(f\"{'':20s}  {'free':>12s}  {'element pool':>12s}\")\n",
     "print(f\"{'Mg_Na':20s}  {free_cd['Mg_Na']:12.3e}  {elem_cd['Mg_Na']:12.3e}  cm⁻³\")\n",
@@ -911,10 +909,10 @@
    "execution_count": 16,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:17:23.283464Z",
-     "iopub.status.busy": "2026-07-11T20:17:23.283375Z",
-     "iopub.status.idle": "2026-07-11T20:17:34.480767Z",
-     "shell.execute_reply": "2026-07-11T20:17:34.480374Z"
+     "iopub.execute_input": "2026-07-13T14:38:23.564998Z",
+     "iopub.status.busy": "2026-07-13T14:38:23.564887Z",
+     "iopub.status.idle": "2026-07-13T14:38:35.258953Z",
+     "shell.execute_reply": "2026-07-13T14:38:35.258609Z"
     }
    },
    "outputs": [
@@ -942,7 +940,7 @@
     "Mg_total   = []\n",
     "\n",
     "for t in temperatures:\n",
-    "    cd = elem_factory.at(t).concentration_dict()\n",
+    "    cd = elem_factory.at(t).result.concentrations\n",
     "    Mg_Na_conc.append(cd[\"Mg_Na\"])\n",
     "    Mg_i_conc.append(cd[\"Mg_i\"])\n",
     "    Mg_total.append(cd[\"Mg_Na\"] + cd[\"Mg_i\"])\n",
@@ -978,10 +976,10 @@
    "execution_count": 17,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:17:34.482876Z",
-     "iopub.status.busy": "2026-07-11T20:17:34.482642Z",
-     "iopub.status.idle": "2026-07-11T20:17:34.485693Z",
-     "shell.execute_reply": "2026-07-11T20:17:34.485385Z"
+     "iopub.execute_input": "2026-07-13T14:38:35.261036Z",
+     "iopub.status.busy": "2026-07-13T14:38:35.260861Z",
+     "iopub.status.idle": "2026-07-13T14:38:35.263916Z",
+     "shell.execute_reply": "2026-07-13T14:38:35.263640Z"
     }
    },
    "outputs": [
@@ -1021,10 +1019,10 @@
    "execution_count": 18,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:17:34.487319Z",
-     "iopub.status.busy": "2026-07-11T20:17:34.487194Z",
-     "iopub.status.idle": "2026-07-11T20:17:34.605459Z",
-     "shell.execute_reply": "2026-07-11T20:17:34.605177Z"
+     "iopub.execute_input": "2026-07-13T14:38:35.265489Z",
+     "iopub.status.busy": "2026-07-13T14:38:35.265384Z",
+     "iopub.status.idle": "2026-07-13T14:38:35.382915Z",
+     "shell.execute_reply": "2026-07-13T14:38:35.382595Z"
     }
    },
    "outputs": [
@@ -1065,9 +1063,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To inspect per-charge-state concentrations at the `DefectSystem` level, use `charge_state_concentration_dict()`. It returns a plain `{species_name: {key: conc}}` dict with one entry per `DefectChargeState` and no metadata. The key is the charge state's `name`: an explicit name where one was set, otherwise the charge-derived default such as `\"q+3\"`.\n",
+    "To inspect per-charge-state concentrations at the `DefectSystem` level, use `result.charge_state_concentrations`. This is a `{species_name: {name: conc}}` dict with one entry per `DefectChargeState`, in cm$^{-3}$. The inner key is the charge state's `name`: an explicit name where one was set, otherwise the charge-derived default such as `\"q+3\"`. `result.charge_state_concentrations_per_cell` gives the same breakdown per unit cell.\n",
     "\n",
-    "`concentration_dict(decomposed=True)` uses the same key scheme and gives one entry per `DefectChargeState`; its outer dict additionally contains `\"Fermi Energy\"`, `\"p0\"`, and `\"n0\"` keys alongside the species entries. Use `charge_state_concentration_dict()` when you only want the defect concentrations without those extras."
+    "The self-consistent Fermi energy and the electron and hole concentrations are on the same `result` object too, as `result.fermi_energy`, `result.p0` and `result.n0`."
    ]
   },
   {
@@ -1075,10 +1073,10 @@
    "execution_count": 19,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:17:34.607309Z",
-     "iopub.status.busy": "2026-07-11T20:17:34.607199Z",
-     "iopub.status.idle": "2026-07-11T20:17:34.617620Z",
-     "shell.execute_reply": "2026-07-11T20:17:34.617374Z"
+     "iopub.execute_input": "2026-07-13T14:38:35.384868Z",
+     "iopub.status.busy": "2026-07-13T14:38:35.384666Z",
+     "iopub.status.idle": "2026-07-13T14:38:35.393592Z",
+     "shell.execute_reply": "2026-07-13T14:38:35.392992Z"
     }
    },
    "outputs": [
@@ -1093,7 +1091,7 @@
       "  q+3: 3.498e-26\n",
       "\n",
       "Fermi energy: 2.859 eV\n",
-      "Al_i entries from decomposed dict:\n",
+      "Al_i charge-state concentrations (cm⁻³):\n",
       "  q+0: 4.136e+15\n",
       "  Al_i_1_tet: 1.104e+10\n",
       "  Al_i_1_oct: 4.700e+09\n",
@@ -1109,18 +1107,17 @@
     "    temperature=1500,\n",
     ")\n",
     "\n",
-    "cs_concs = Al_i_system.charge_state_concentration_dict(per_volume=False)\n",
+    "result = Al_i_system.result\n",
     "\n",
+    "cs_concs = result.charge_state_concentrations_per_cell\n",
     "print(\"Al_i charge-state concentrations at 1500 K (per unit cell):\")\n",
     "for key, conc in cs_concs[\"Al_i\"].items():\n",
     "    print(f\"  {key}: {conc:.3e}\")\n",
     "\n",
-    "# concentration_dict(decomposed=True) uses the same keys but also includes\n",
-    "# 'Fermi Energy', 'p0', and 'n0' in the outer dict:\n",
-    "decomp = Al_i_system.concentration_dict(decomposed=True)\n",
-    "print(f\"\\nFermi energy: {decomp['Fermi Energy']:.3f} eV\")\n",
-    "print(\"Al_i entries from decomposed dict:\")\n",
-    "for key, conc in decomp[\"Al_i\"].items():\n",
+    "# the same breakdown in cm⁻³, with the Fermi energy alongside on the result object\n",
+    "print(f\"\\nFermi energy: {result.fermi_energy:.3f} eV\")\n",
+    "print(\"Al_i charge-state concentrations (cm⁻³):\")\n",
+    "for key, conc in result.charge_state_concentrations[\"Al_i\"].items():\n",
     "    print(f\"  {key}: {conc:.3e}\")"
    ]
   },
@@ -1144,10 +1141,10 @@
    "execution_count": 20,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:17:34.619028Z",
-     "iopub.status.busy": "2026-07-11T20:17:34.618936Z",
-     "iopub.status.idle": "2026-07-11T20:17:34.621104Z",
-     "shell.execute_reply": "2026-07-11T20:17:34.620876Z"
+     "iopub.execute_input": "2026-07-13T14:38:35.395635Z",
+     "iopub.status.busy": "2026-07-13T14:38:35.395511Z",
+     "iopub.status.idle": "2026-07-13T14:38:35.397901Z",
+     "shell.execute_reply": "2026-07-13T14:38:35.397651Z"
     }
    },
    "outputs": [
@@ -1191,10 +1188,10 @@
    "execution_count": 21,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:17:34.622418Z",
-     "iopub.status.busy": "2026-07-11T20:17:34.622337Z",
-     "iopub.status.idle": "2026-07-11T20:17:34.624580Z",
-     "shell.execute_reply": "2026-07-11T20:17:34.624347Z"
+     "iopub.execute_input": "2026-07-13T14:38:35.400053Z",
+     "iopub.status.busy": "2026-07-13T14:38:35.399844Z",
+     "iopub.status.idle": "2026-07-13T14:38:35.403274Z",
+     "shell.execute_reply": "2026-07-13T14:38:35.402844Z"
     }
    },
    "outputs": [
@@ -1242,10 +1239,10 @@
    "execution_count": 22,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:17:34.625944Z",
-     "iopub.status.busy": "2026-07-11T20:17:34.625866Z",
-     "iopub.status.idle": "2026-07-11T20:17:34.627942Z",
-     "shell.execute_reply": "2026-07-11T20:17:34.627695Z"
+     "iopub.execute_input": "2026-07-13T14:38:35.404956Z",
+     "iopub.status.busy": "2026-07-13T14:38:35.404840Z",
+     "iopub.status.idle": "2026-07-13T14:38:35.407303Z",
+     "shell.execute_reply": "2026-07-13T14:38:35.406968Z"
     }
    },
    "outputs": [
@@ -1296,10 +1293,10 @@
    "execution_count": 23,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-11T20:17:34.629358Z",
-     "iopub.status.busy": "2026-07-11T20:17:34.629276Z",
-     "iopub.status.idle": "2026-07-11T20:17:35.132244Z",
-     "shell.execute_reply": "2026-07-11T20:17:35.131959Z"
+     "iopub.execute_input": "2026-07-13T14:38:35.409000Z",
+     "iopub.status.busy": "2026-07-13T14:38:35.408862Z",
+     "iopub.status.idle": "2026-07-13T14:38:35.955270Z",
+     "shell.execute_reply": "2026-07-13T14:38:35.954951Z"
     }
    },
    "outputs": [

--- a/py_sc_fermi/defect_charge_state.py
+++ b/py_sc_fermi/defect_charge_state.py
@@ -22,11 +22,11 @@ class DefectChargeState:
          fixed_concentration (float): fixed concentration per unit cell.
            Must be finite and non-negative.
          name (str | None): identifying label for this charge state, used as
-           the key in ``DefectSystem.charge_state_concentration_dict`` and
-           ``concentration_dict(decomposed=True)``. Defaults to the charge
-           string (e.g. ``"q+2"``). Metastable configurations sharing a formal
-           charge must be given explicit names (e.g. ``"V_O_2+_tet"`` vs
-           ``"V_O_2+_oct"``), since names must be unique within a
+           the key in ``DefectSystem.result.charge_state_concentrations``
+           (keyed by species name then charge-state name). Defaults to the
+           charge string (e.g. ``"q+2"``). Metastable configurations sharing a
+           formal charge must be given explicit names (e.g. ``"V_O_2+_tet"``
+           vs ``"V_O_2+_oct"``), since names must be unique within a
            ``DefectSpecies``.
     """
 

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -1420,14 +1420,14 @@ class DefectSystemFactory:
         cbm_shift_fn (Callable[[float], float] | None, optional): a function
           of temperature returning the conduction-band-minimum shift (in eV)
           at that temperature. Defaults to None (no shift).
-        formation_energy_correction_fns (dict[CorrectionKey, Callable[[float], float]] | None,
-          optional): per-charge-state temperature-dependent formation-energy
-          corrections. Each callable takes a temperature in K and returns a
-          correction in eV to add to that charge state's formation energy at
-          each snapshot. Keys identify a charge state either as the
-          `DefectChargeState` object or as a `(species_name, charge_state_name)`
-          pair; they are resolved when `at()` builds each `DefectSystem`.
-          Defaults to None.
+        formation_energy_correction_fns (dict | None, optional): per-charge-state
+          temperature-dependent formation-energy corrections, as a mapping
+          ``dict[CorrectionKey, Callable[[float], float]]``. Each callable
+          takes a temperature in K and returns a correction in eV to add to
+          that charge state's formation energy at each snapshot. Keys
+          identify a charge state either as the `DefectChargeState` object or
+          as a `(species_name, charge_state_name)` pair; they are resolved
+          when `at()` builds each `DefectSystem`. Defaults to None.
         rigid_shift (bool, optional): passed to every `DefectSystem` built by
           `at()`. Defaults to True.
         occupancy_warning_threshold (float | None, optional): passed to every

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -174,6 +174,10 @@ class DefectSystem:
           hosts), or set ``None`` to silence the warning. Must be ``None`` or a
           finite fraction in (0, 1]. This is a reporting preference, not part of
           the physical system, and is not serialised. Defaults to 0.01.
+        label (str | None, optional): an optional human-readable tag for this
+          system (e.g. a growth condition or sample name), useful for
+          identifying it within a batch of related systems. Included in
+          ``as_dict`` only when set. Defaults to None.
 
     Raises:
         ValueError: if two entries in `defect_species` share a name, a pool
@@ -213,6 +217,7 @@ class DefectSystem:
         rigid_shift: bool = True,
         fixed_concentrations: dict[FixedConcentrationKey, float] | None = None,
         occupancy_warning_threshold: float | None = 0.01,
+        label: str | None = None,
     ):
         self._volume = volume
         self._dos = dos
@@ -220,6 +225,7 @@ class DefectSystem:
         if delta_gap != 0.0:
             self._dos = self._dos.scissored(delta_gap)
         self._temperature = temperature
+        self._label = label
         self._convergence_tolerance = convergence_tolerance
         self._vbm_shift = vbm_shift
         self._cbm_shift = cbm_shift
@@ -251,6 +257,11 @@ class DefectSystem:
     @property
     def temperature(self) -> float:
         return self._temperature
+
+    @property
+    def label(self) -> str | None:
+        """An optional human-readable tag for this system, serialised when set."""
+        return self._label
 
     @property
     def convergence_tolerance(self) -> float | None:
@@ -1041,8 +1052,9 @@ class DefectSystem:
             ],
             site_pools=site_pools,
             element_pools=element_pools,
+            label=dictionary.get("label"),
         )
-        
+
     def defect_species_by_name(self, name: str) -> DefectSpecies:
         """return a ``DefectSpecies`` contained within the ``DefectSystem``
         via its name.
@@ -1479,6 +1491,8 @@ class DefectSystem:
         )
         if self.convergence_tolerance is not None:
             defect_system_dict["convergence_tolerance"] = float(self.convergence_tolerance)
+        if self.label is not None:
+            defect_system_dict["label"] = self.label
         if self.site_pools:
             defect_system_dict["site_pools"] = {
                 name: pool.as_dict() for name, pool in self.site_pools.items()
@@ -1535,6 +1549,8 @@ class DefectSystemFactory:
           `DefectSystem` built by `at()`, so a temperature sweep warns
           consistently. See `DefectSystem` for its meaning and validation.
           Defaults to 0.01.
+        label (str | None, optional): passed to every `DefectSystem` built by
+          `at()`, unless overridden per call. Defaults to None.
     """
 
     def __init__(
@@ -1552,6 +1568,7 @@ class DefectSystemFactory:
         ) = None,
         rigid_shift: bool = True,
         occupancy_warning_threshold: float | None = 0.01,
+        label: str | None = None,
     ):
         self.defect_species = defect_species
         self.dos = dos
@@ -1564,6 +1581,7 @@ class DefectSystemFactory:
         self.formation_energy_correction_fns = formation_energy_correction_fns or {}
         self.rigid_shift = rigid_shift
         self.occupancy_warning_threshold = occupancy_warning_threshold
+        self.label = label
 
     def at(self, temperature: float, **overrides: Any) -> DefectSystem:
         """Build a `DefectSystem` snapshot at `temperature`.
@@ -1613,6 +1631,7 @@ class DefectSystemFactory:
             formation_energy_corrections=formation_energy_corrections,
             rigid_shift=self.rigid_shift,
             occupancy_warning_threshold=self.occupancy_warning_threshold,
+            label=self.label,
         )
         kwargs.update(overrides)
         return DefectSystem(**kwargs)

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -1122,12 +1122,12 @@ class DefectSystem:
         )
         if not offenders:
             return
-        self._occupancy_warning_emitted = True
         warnings.warn(
             self._high_occupancy_message(offenders),
             DiluteLimitWarning,
             stacklevel=self._warning_stacklevel(),
         )
+        self._occupancy_warning_emitted = True
 
     @staticmethod
     def _warning_stacklevel() -> int:

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -191,7 +191,7 @@ class DefectSystem:
           or a finite fraction in (0, 1].
 
     Note:
-        `DefectSystem` is a fixed-temperature snapshot whose physical public
+        `DefectSystem` is a fixed-temperature snapshot whose public
         attributes are read-only once constructed: rebinding any of them raises
         `AttributeError`. `vbm_shift`, `cbm_shift`,
         `formation_energy_corrections`, `rigid_shift`, and
@@ -297,24 +297,6 @@ class DefectSystem:
     @property
     def occupancy_warning_threshold(self) -> float | None:
         return self._occupancy_warning_threshold
-
-    @occupancy_warning_threshold.setter
-    def occupancy_warning_threshold(self, value: float | None) -> None:
-        """Set the dilute-limit warning threshold.
-
-        Validates ``value`` (see ``__init__``) and, when it differs from the
-        current threshold, re-arms the once-per-instance dilute-limit warning
-        so the next solve re-evaluates site occupancy against the new
-        threshold.
-
-        Raises:
-            ValueError: if ``value`` is not ``None`` or a finite fraction in
-                (0, 1].
-        """
-        validated = self._validate_occupancy_warning_threshold(value)
-        if validated != self._occupancy_warning_threshold:
-            self._occupancy_warning_emitted = False
-        self._occupancy_warning_threshold = validated
 
     @staticmethod
     def _validate_occupancy_warning_threshold(value: float | None) -> float | None:

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -1428,18 +1428,20 @@ class DefectSystem:
 
         The occupancies are drawn from the same solved, pool- and
         exclusion-aware concentrations as ``report`` and ``concentration_dict``
-        (``_global_defect_concs`` at the self-consistent Fermi level). The
-        denominator is the sites available to the species -- its own
-        ``nsites``, or, for a species in a ``site_pools`` entry, the pool's
-        total site count (so a pool's members together occupy at most 100% of
-        it). A species' concentration cannot exceed its available sites, so
-        every occupancy is at most 100%.
+        (``_global_defect_concs`` at ``result.fermi_energy``). The denominator
+        is the sites available to the species -- its own ``nsites``, or, for a
+        species in a ``site_pools`` entry, the pool's total site count (so a
+        pool's members together occupy at most 100% of it). A species'
+        concentration cannot exceed its available sites, so every occupancy is
+        at most 100%.
+
+        Reads the cached ``result`` rather than re-solving.
 
         Returns:
             dict[str, float]: mapping of ``DefectSpecies`` name to its site
             occupancy as a percentage.
         """
-        e_fermi = self.get_sc_fermi()[0]
+        e_fermi = self.result.fermi_energy
         return {
             name: fraction * 100
             for name, fraction in self._site_occupancy_fractions(e_fermi).items()
@@ -1449,8 +1451,8 @@ class DefectSystem:
         """Solved chemical-potential shifts for each constrained element.
 
         Returns the chemical-potential shift ``delta_mu`` (in eV) of every
-        element constrained by ``element_pools``, evaluated at the
-        self-consistent Fermi level. ``delta_mu`` is measured relative to the
+        element constrained by ``element_pools``, evaluated at
+        ``result.fermi_energy``. ``delta_mu`` is measured relative to the
         chemical-potential reference at which the formation energies were
         defined: a target above the element's unconstrained content gives
         ``delta_mu > 0``, a target below it ``delta_mu < 0``, and a target
@@ -1467,6 +1469,8 @@ class DefectSystem:
         used for the concentrations at this Fermi level, so it is consistent
         with ``concentration_dict``.
 
+        Reads the cached ``result`` rather than re-solving.
+
         Returns:
             dict[str, float]: each constrained element mapped to its
             ``delta_mu`` in eV, in the order the pools were declared. Empty
@@ -1482,7 +1486,7 @@ class DefectSystem:
         """
         if not self.element_pools:
             return {}
-        e_fermi = self.get_sc_fermi()[0]
+        e_fermi = self.result.fermi_energy
         groups, _ = self._build_exclusion_groups(e_fermi)
         pools = self._resolve_element_pools()
         elements = list(pools)

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -119,13 +119,13 @@ class DefectSystem:
           at E=0, `vbm_shift` narrows the gap. Separately, when
           `rigid_shift=False`, `-charge * vbm_shift` is added to every
           variable-concentration charge state's formation energy. Also sets the
-          effective band gap shown by `__repr__`/`report`. Defaults to 0.0.
+          effective band gap shown by `__repr__`. Defaults to 0.0.
         cbm_shift (float, optional): a temperature-dependent shift of the
           conduction-band minimum, in eV, evaluated by the caller for this
           system's `temperature`. Enters only through the DOS scissor: the band
           gap changes by `cbm_shift - vbm_shift`, moving the conduction block
           (and the carrier concentrations) and setting the effective band gap
-          shown by `__repr__`/`report`. Defaults to 0.0 (no shift).
+          shown by `__repr__`. Defaults to 0.0 (no shift).
         formation_energy_corrections (dict[CorrectionKey, float] | None, optional):
           per-charge-state formation-energy corrections (in eV), evaluated by
           the caller for this system's `temperature`. Each key identifies one
@@ -659,61 +659,6 @@ class DefectSystem:
         """
         return [ds.name for ds in self.defect_species]
 
-    def report(self) -> str:
-        """Solve for the self-consistent Fermi energy and print a summary of
-        the system: SC Fermi energy, carrier concentrations, and per-species
-        and per-charge-state defect concentrations.
-
-        Returns:
-            str: the formatted report (also printed to stdout)
-        """
-        scale = 1e24 / self.volume
-        e_fermi, _ = self.get_sc_fermi()
-        p0, n0 = self.dos.carrier_concentrations(e_fermi, self.temperature)
-
-        # pool-aware per-charge-state concentrations (per unit cell)
-        cs_concs = self._global_defect_concs(e_fermi)
-
-        # group concentrations back to their parent DefectSpecies
-        sp_cs: dict[str, list[tuple[DefectChargeState, float]]] = {
-            ds.name: [] for ds in self.defect_species
-        }
-        for ds in self.defect_species:
-            for cs in ds.charge_states:
-                if cs in cs_concs:
-                    sp_cs[ds.name].append((cs, cs_concs[cs]))
-
-        lines = [
-            repr(self),
-            "",
-            f"SC Fermi energy:  {e_fermi:.6f} eV",
-            "",
-            "Carriers:",
-            f"  p0 (holes):     {p0 * scale:.3e} cm\u207b\u00b3",
-            f"  n0 (electrons): {n0 * scale:.3e} cm\u207b\u00b3",
-            "",
-            "Defect concentrations:",
-        ]
-        for ds in self.defect_species:
-            cs_list = sp_cs[ds.name]
-            sp_total = sum(c for _, c in cs_list) * scale
-            header = f"  {ds.name:<16s}  {sp_total:.3e} cm\u207b\u00b3"
-            if ds.fixed_concentration is not None:
-                header += "  [fixed]"
-            lines.append(header)
-            total_per_cell = sum(c for _, c in cs_list)
-            for cs, conc in sorted(cs_list, key=lambda x: x[0].charge):
-                pct = 100 * conc / total_per_cell if total_per_cell > 0 else 0.0
-                flag = "  [fixed]" if cs.fixed_concentration is not None else ""
-                lines.append(
-                    f"    q = {cs.charge:+2d}   {conc * scale:.3e} cm\u207b\u00b3"
-                    f"  ({pct:6.2f}%){flag}"
-                )
-
-        output = "\n".join(lines)
-        print(output)
-        return output
-
     def _resolve_species(self, name: str) -> DefectSpecies:
         """Resolve a species name to its entry in the roster."""
         return self.defect_species_by_name(name)
@@ -1106,7 +1051,7 @@ class DefectSystem:
                 p0_per_cell=float(p0),
                 n0_per_cell=float(n0),
                 charge_state_concentrations_per_cell=self._per_charge_state_concs(
-                    e_fermi, 1.0
+                    e_fermi
                 ),
             )
         return self._result
@@ -1166,10 +1111,10 @@ class DefectSystem:
         emits one warning naming every offending species and its occupancy,
         worst first. The warning fires at most once per ``DefectSystem``: the
         occupancy verdict is deterministic for an immutable snapshot, so a user
-        inspecting one solved system through several methods (``report``,
-        ``concentration_dict``, ``site_percentages``, a direct ``get_sc_fermi``)
-        sees a single warning, attributed to their own call rather than to an
-        internal solve method.
+        inspecting one solved system through several routes (a direct
+        ``get_sc_fermi``, or the deeper ``result``, ``site_percentages`` or
+        ``element_chemical_potential_shifts``) sees a single warning, attributed
+        to their own call rather than to an internal solve method.
 
         Args:
             e_fermi (float): the self-consistent Fermi energy from
@@ -1203,12 +1148,14 @@ class DefectSystem:
         points at the first frame outside this module.
 
         The warning is reached at different stack depths -- directly via
-        ``get_sc_fermi``, or one frame deeper via ``report``,
-        ``concentration_dict`` or ``site_percentages`` -- so no fixed
-        ``stacklevel`` blames the caller on every path. Counting frames up to
-        the first one outside ``py_sc_fermi.defect_system`` attributes the
-        warning to the user's call. ``warnings.warn`` is invoked one frame above
-        this helper, where the count begins.
+        ``get_sc_fermi``, or more deeply through the ``result`` property
+        (accessed as ``system.result``, or via ``site_percentages`` or
+        ``element_chemical_potential_shifts``, which read
+        ``result.fermi_energy``) -- so no fixed ``stacklevel`` blames the
+        caller on every path. Counting frames up to the first one outside
+        ``py_sc_fermi.defect_system`` attributes the warning to the user's
+        call. ``warnings.warn`` is invoked one frame above this helper, where
+        the count begins.
         """
         frame: Any = sys._getframe(1)
         level = 1
@@ -1292,108 +1239,23 @@ class DefectSystem:
             transition_levels.update({defect_species: [x, y]})
         return transition_levels
 
-    def _per_charge_state_concs(
-        self, e_fermi: float, scale: float
-    ) -> dict[str, dict[str, float]]:
-        """Per-species, per-charge-state concentrations at ``e_fermi``,
-        multiplied by ``scale``, keyed by species name then charge-state name.
+    def _per_charge_state_concs(self, e_fermi: float) -> dict[str, dict[str, float]]:
+        """Per-species, per-charge-state concentrations per unit cell at
+        ``e_fermi``, keyed by species name then charge-state name.
         """
         cs_concs = self._global_defect_concs(e_fermi)
         return {
-            ds.name: {
-                cs.name: float(cs_concs[cs] * scale)
-                for cs in ds.charge_states
-            }
+            ds.name: {cs.name: float(cs_concs[cs]) for cs in ds.charge_states}
             for ds in self.defect_species
         }
-
-    def concentration_dict(
-        self,
-        decomposed: bool = False,
-        per_volume: bool = True,
-    ) -> dict[str, Any]:
-        """Returns a dictionary of solved Fermi energy, carrier concentrations,
-        and defect concentrations for this ``DefectSystem``.
-
-        The returned dict always contains ``"Fermi Energy"``, ``"p0"``
-        (holes), and ``"n0"`` (electrons). Each defect species then
-        contributes one or more additional keys:
-
-        - ``decomposed=False`` (default): one key per species, mapping to
-          its total concentration (sum over all charge states).
-        - ``decomposed=True``: one key per species, mapping to a nested
-          ``dict[str, float]`` with one entry per ``DefectChargeState``,
-          keyed by ``cs.name`` (an explicit name, or the charge-derived
-          default such as ``"q+2"``).
-
-        Use ``charge_state_concentration_dict()`` when you want per-charge-state
-        concentrations without the ``"Fermi Energy"``/``"p0"``/``"n0"`` metadata.
-
-        Args:
-            decomposed (bool, optional): if True, return per-charge-state
-              concentrations in a nested dict keyed by charge-state name.
-              Defaults to False.
-            per_volume (bool, optional): if True, return concentrations in units
-              of cm^-3, else returns concentration per unit cell. Defaults to True.
-
-        Returns:
-            dict[str, Any]: dictionary with ``"Fermi Energy"``, ``"p0"``,
-            ``"n0"``, and one entry per defect species.
-        """
-        if per_volume:
-            scale = 1e24 / self.volume
-        else:
-            scale = 1
-
-        e_fermi = self.get_sc_fermi()[0]
-        p0, n0 = self.dos.carrier_concentrations(e_fermi, self.temperature)
-        run_stats = {
-            "Fermi Energy": float(e_fermi),
-            "p0": float(p0 * scale),
-            "n0": float(n0 * scale),
-        }
-        if not decomposed:
-            cs_concs = self._global_defect_concs(e_fermi)
-            sum_concs = {}
-            for ds in self.defect_species:
-                total = sum(cs_concs[cs] for cs in ds.charge_states)
-                sum_concs[ds.name] = float(total * scale)
-            return {**run_stats, **sum_concs}
-        else:
-            return {**run_stats, **self._per_charge_state_concs(e_fermi, scale)}
-
-    def charge_state_concentration_dict(
-        self,
-        per_volume: bool = True,
-    ) -> dict[str, dict[str, float]]:
-        """Return per-charge-state concentrations keyed by species name and
-        charge-state name.
-
-        Every ``DefectChargeState`` appears as a separate entry, keyed by
-        ``cs.name`` (an explicit name, or the charge-derived default such as
-        ``"q+2"``). ``concentration_dict(decomposed=True)`` returns the same
-        per-species entries with the ``"Fermi Energy"``/``"p0"``/``"n0"``
-        metadata alongside them.
-
-        Args:
-            per_volume (bool, optional): if True, return concentrations in units
-              of cm^-3, else returns concentration per unit cell. Defaults to True.
-
-        Returns:
-            dict[str, dict[str, float]]: mapping from species name to a dict of
-            ``{charge_state_name: concentration}``, one entry per charge state.
-        """
-        scale = 1e24 / self.volume if per_volume else 1
-        e_fermi = self.get_sc_fermi()[0]
-        return self._per_charge_state_concs(e_fermi, scale)
 
     def _site_occupancy_fractions(self, e_fermi: float) -> dict[str, float]:
         """Return each ``DefectSpecies``' site occupancy as a fraction of the
         sites available to it, at an already-solved Fermi level.
 
-        The concentrations are the same pool- and exclusion-aware values used
-        by ``report`` and ``concentration_dict`` (``_global_defect_concs`` at
-        ``e_fermi``). The denominator is the sites available to the species:
+        The concentrations are the same pool- and exclusion-aware values
+        underlying ``result`` (``_global_defect_concs`` at ``e_fermi``). The
+        denominator is the sites available to the species:
         the pool's total site count for a species in a ``site_pools`` entry,
         otherwise its own ``nsites``. This is the fractional form of
         ``site_percentages`` (which scales it by 100); both draw on a single
@@ -1427,8 +1289,8 @@ class DefectSystem:
         percentage of the sites available to it.
 
         The occupancies are drawn from the same solved, pool- and
-        exclusion-aware concentrations as ``report`` and ``concentration_dict``
-        (``_global_defect_concs`` at ``result.fermi_energy``). The denominator
+        exclusion-aware concentrations as ``result`` (``_global_defect_concs``
+        at ``result.fermi_energy``). The denominator
         is the sites available to the species -- its own ``nsites``, or, for a
         species in a ``site_pools`` entry, the pool's total site count (so a
         pool's members together occupy at most 100% of it). A species'
@@ -1467,7 +1329,7 @@ class DefectSystem:
 
         The shift is re-derived from the same deterministic element-pool solve
         used for the concentrations at this Fermi level, so it is consistent
-        with ``concentration_dict``.
+        with ``result``.
 
         Reads the cached ``result`` rather than re-solving.
 

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -1029,7 +1029,7 @@ class DefectSystem:
             per_cell = self._per_charge_state_concs(e_fermi)
             self._result = DefectSystemResult(
                 temperature=float(self.temperature),
-                fermi_energy=e_fermi,
+                fermi_energy=float(e_fermi),
                 volume=float(self.volume),
                 label=self.label,
                 p0_per_cell=float(p0),

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -7,6 +7,7 @@ import warnings
 from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Any, NamedTuple
 
 import numpy as np
@@ -1025,6 +1026,7 @@ class DefectSystem:
         if self._result is None:
             e_fermi, _ = self.get_sc_fermi()
             p0, n0 = self.dos.carrier_concentrations(e_fermi, self.temperature)
+            per_cell = self._per_charge_state_concs(e_fermi)
             self._result = DefectSystemResult(
                 temperature=float(self.temperature),
                 fermi_energy=e_fermi,
@@ -1032,8 +1034,11 @@ class DefectSystem:
                 label=self.label,
                 p0_per_cell=float(p0),
                 n0_per_cell=float(n0),
-                charge_state_concentrations_per_cell=self._per_charge_state_concs(
-                    e_fermi
+                charge_state_concentrations_per_cell=MappingProxyType(
+                    {
+                        species: MappingProxyType(states)
+                        for species, states in per_cell.items()
+                    }
                 ),
             )
         return self._result

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -1026,9 +1026,9 @@ class DefectSystem:
             e_fermi, _ = self.get_sc_fermi()
             p0, n0 = self.dos.carrier_concentrations(e_fermi, self.temperature)
             self._result = DefectSystemResult(
-                temperature=self.temperature,
+                temperature=float(self.temperature),
                 fermi_energy=e_fermi,
-                volume=self.volume,
+                volume=float(self.volume),
                 label=self.label,
                 p0_per_cell=float(p0),
                 n0_per_cell=float(n0),

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -16,6 +16,7 @@ from scipy.optimize import brentq
 from py_sc_fermi import element_pools
 from py_sc_fermi.defect_charge_state import DefectChargeState
 from py_sc_fermi.defect_species import DefectSpecies
+from py_sc_fermi.defect_system_result import DefectSystemResult
 from py_sc_fermi.dos import DOS
 from py_sc_fermi.element_pools import ElementPoolError
 from py_sc_fermi.pools import (
@@ -226,6 +227,7 @@ class DefectSystem:
             self._dos = self._dos.scissored(delta_gap)
         self._temperature = temperature
         self._label = label
+        self._result: DefectSystemResult | None = None
         self._convergence_tolerance = convergence_tolerance
         self._vbm_shift = vbm_shift
         self._cbm_shift = cbm_shift
@@ -260,7 +262,8 @@ class DefectSystem:
 
     @property
     def label(self) -> str | None:
-        """An optional human-readable tag for this system, serialised when set."""
+        """An optional human-readable tag for this system, copied into
+        ``result`` and serialised when set."""
         return self._label
 
     @property
@@ -1074,6 +1077,40 @@ class DefectSystem:
         available = ", ".join(self.defect_species_names)
         raise ValueError(f"no defect species named '{name}'; available: {available}")
     
+    @property
+    def result(self) -> DefectSystemResult:
+        """The solved state of this system as a ``DefectSystemResult``.
+
+        Solves for the self-consistent Fermi energy on first access and caches
+        the result; subsequent accesses return the same object without
+        re-solving. Safe to cache unconditionally because the system is an
+        immutable snapshot.
+
+        Returns:
+            DefectSystemResult: the Fermi level, carrier and defect
+            concentrations at the self-consistent Fermi energy.
+        """
+        # Deliberately a manual cache, not functools.cached_property: the latter
+        # inserts a functools frame that DiluteLimitWarning's attribution walk
+        # (_warning_stacklevel) stops at, misattributing the warning to
+        # functools.py instead of the caller. See
+        # test_result_warning_is_attributed_to_caller.
+        if self._result is None:
+            e_fermi, _ = self.get_sc_fermi()
+            p0, n0 = self.dos.carrier_concentrations(e_fermi, self.temperature)
+            self._result = DefectSystemResult(
+                temperature=self.temperature,
+                fermi_energy=e_fermi,
+                volume=self.volume,
+                label=self.label,
+                p0_per_cell=float(p0),
+                n0_per_cell=float(n0),
+                charge_state_concentrations_per_cell=self._per_charge_state_concs(
+                    e_fermi, 1.0
+                ),
+            )
+        return self._result
+
     def get_sc_fermi(self) -> tuple[float, float]:
         """Calculate the self-consistent Fermi energy.
         

--- a/py_sc_fermi/defect_system_result.py
+++ b/py_sc_fermi/defect_system_result.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 
 
@@ -14,7 +15,7 @@ class DefectSystemResult:
     derived from the per-charge-state breakdown, so the two cannot disagree.
 
     Supports value equality, but is unhashable: ``charge_state_concentrations_per_cell``
-    nests plain ``dict``s, so no field-derived hash can be computed.
+    nests mappings, so no field-derived hash can be computed.
 
     Attributes:
         temperature: temperature of the solve, in K.
@@ -34,10 +35,11 @@ class DefectSystemResult:
     label: str | None
     p0_per_cell: float
     n0_per_cell: float
-    charge_state_concentrations_per_cell: dict[str, dict[str, float]]
+    charge_state_concentrations_per_cell: Mapping[str, Mapping[str, float]]
 
-    # Left unhashable rather than inheriting a dataclass-synthesised __hash__
-    # that would raise at call time over the nested dict field.
+    # @dataclass synthesises __hash__ onto this class; setting __hash__ = None
+    # keeps instances unhashable, as they hold dict/mapping fields that a
+    # synthesised hash would raise over at call time.
     __hash__ = None  # type: ignore[assignment]
 
     @property
@@ -122,7 +124,7 @@ class DefectSystemResult:
         total. Describes the solution only; ``repr()`` of the originating
         ``DefectSystem`` describes the system.
         """
-        cm3 = "cm\u207b\u00b3"  # cm to the minus three, written with Unicode escapes
+        cm3 = "cm\u207b\u00b3"  # cm to the minus three
         lines = [
             f"SC Fermi energy:  {self.fermi_energy:.6f} eV",
             "",

--- a/py_sc_fermi/defect_system_result.py
+++ b/py_sc_fermi/defect_system_result.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DefectSystemResult:
+    """The solved state of a ``DefectSystem``: Fermi level, carrier and defect
+    concentrations at the self-consistent Fermi energy.
+
+    Constructed by ``DefectSystem.result``; users normally read it rather than
+    build it. Canonical concentrations are stored per unit cell; the cm^-3 views
+    (the common default) are derived using ``volume``. Per-species totals are
+    derived from the per-charge-state breakdown, so the two cannot disagree.
+
+    Supports value equality, but is unhashable: ``charge_state_concentrations_per_cell``
+    nests plain ``dict``s, so no field-derived hash can be computed.
+
+    Attributes:
+        temperature: temperature of the solve, in K.
+        fermi_energy: the self-consistent Fermi energy, in eV.
+        volume: volume of the unit cell in Angstroms cubed, used for the cm^-3
+            views.
+        label: an optional human tag copied from the ``DefectSystem``.
+        p0_per_cell: hole concentration per unit cell.
+        n0_per_cell: electron concentration per unit cell.
+        charge_state_concentrations_per_cell: per-unit-cell concentrations keyed
+            by species name then charge-state name.
+    """
+
+    temperature: float
+    fermi_energy: float
+    volume: float
+    label: str | None
+    p0_per_cell: float
+    n0_per_cell: float
+    charge_state_concentrations_per_cell: dict[str, dict[str, float]]
+
+    # Left unhashable rather than inheriting a dataclass-synthesised __hash__
+    # that would raise at call time over the nested dict field.
+    __hash__ = None  # type: ignore[assignment]
+
+    @property
+    def _scale(self) -> float:
+        """Multiplier converting a per-unit-cell concentration to cm^-3."""
+        return 1e24 / self.volume
+
+    @property
+    def p0(self) -> float:
+        """Hole concentration in cm^-3."""
+        return self.p0_per_cell * self._scale
+
+    @property
+    def n0(self) -> float:
+        """Electron concentration in cm^-3."""
+        return self.n0_per_cell * self._scale
+
+    @property
+    def charge_state_concentrations(self) -> dict[str, dict[str, float]]:
+        """Per-charge-state concentrations in cm^-3, keyed by species name then
+        charge-state name."""
+        scale = self._scale
+        return {
+            species: {name: conc * scale for name, conc in states.items()}
+            for species, states in self.charge_state_concentrations_per_cell.items()
+        }
+
+    @property
+    def concentrations_per_cell(self) -> dict[str, float]:
+        """Per-species total concentrations per unit cell (summed over charge
+        states)."""
+        return {
+            species: sum(states.values())
+            for species, states in self.charge_state_concentrations_per_cell.items()
+        }
+
+    @property
+    def concentrations(self) -> dict[str, float]:
+        """Per-species total concentrations in cm^-3 (summed over charge
+        states)."""
+        return {
+            species: sum(states.values())
+            for species, states in self.charge_state_concentrations.items()
+        }

--- a/py_sc_fermi/defect_system_result.py
+++ b/py_sc_fermi/defect_system_result.py
@@ -114,3 +114,29 @@ class DefectSystemResult:
             f"DefectSystemResult(fermi_energy={self.fermi_energy:.4f} eV, "
             f"temperature={self.temperature:g} K{label})"
         )
+
+    def __str__(self) -> str:
+        """Return a human-readable report of the solved state: Fermi energy,
+        carrier concentrations, and per-species and per-charge-state defect
+        concentrations (cm^-3) with each charge state's share of its species
+        total. Describes the solution only; ``repr()`` of the originating
+        ``DefectSystem`` describes the system.
+        """
+        cm3 = "cm\u207b\u00b3"  # cm to the minus three, written with Unicode escapes
+        lines = [
+            f"SC Fermi energy:  {self.fermi_energy:.6f} eV",
+            "",
+            "Carriers:",
+            f"  p0 (holes):     {self.p0:.3e} {cm3}",
+            f"  n0 (electrons): {self.n0:.3e} {cm3}",
+            "",
+            "Defect concentrations:",
+        ]
+        charge_state_concs = self.charge_state_concentrations
+        for species, states in charge_state_concs.items():
+            species_total = sum(states.values())
+            lines.append(f"  {species:<16s}  {species_total:.3e} {cm3}")
+            for name, conc in states.items():
+                pct = 100 * conc / species_total if species_total > 0 else 0.0
+                lines.append(f"    {name:<6s}   {conc:.3e} {cm3}  ({pct:6.2f}%)")
+        return "\n".join(lines)

--- a/py_sc_fermi/defect_system_result.py
+++ b/py_sc_fermi/defect_system_result.py
@@ -82,3 +82,35 @@ class DefectSystemResult:
             species: sum(states.values())
             for species, states in self.charge_state_concentrations.items()
         }
+
+    def as_dict(self) -> dict:
+        """Return a structured, JSON-safe record of the solved state.
+
+        Concentrations are in cm^-3; ``volume`` is included so per-cell values
+        are recoverable. Keys are snake_case. This is a one-way export: there is
+        no ``from_dict`` (a result is derived by solving a ``DefectSystem``, not
+        reconstructed).
+
+        Returns:
+            dict: ``fermi_energy`` (eV), ``p0`` and ``n0`` (cm^-3),
+            ``temperature`` (K), ``volume`` (cubic Angstrom), ``label``,
+            ``concentrations`` and ``charge_state_concentrations`` (per-species
+            totals and per-charge-state, in cm^-3).
+        """
+        return {
+            "fermi_energy": self.fermi_energy,
+            "p0": self.p0,
+            "n0": self.n0,
+            "temperature": self.temperature,
+            "volume": self.volume,
+            "label": self.label,
+            "concentrations": self.concentrations,
+            "charge_state_concentrations": self.charge_state_concentrations,
+        }
+
+    def __repr__(self) -> str:
+        label = f", label={self.label!r}" if self.label is not None else ""
+        return (
+            f"DefectSystemResult(fermi_energy={self.fermi_energy:.4f} eV, "
+            f"temperature={self.temperature:g} K{label})"
+        )

--- a/py_sc_fermi/warnings.py
+++ b/py_sc_fermi/warnings.py
@@ -17,9 +17,9 @@ class DiluteLimitWarning(PyScFermiWarning):
     so the results may be non-physical.
 
     Emitted by :meth:`DefectSystem.get_sc_fermi` -- and therefore by every
-    results path that solves (``report``, ``concentration_dict``,
-    ``site_percentages``) -- when any species' occupancy exceeds
-    ``DefectSystem.occupancy_warning_threshold``, at most once per
+    results path that solves (``result``, ``site_percentages``,
+    ``element_chemical_potential_shifts``) -- when any species' occupancy
+    exceeds ``DefectSystem.occupancy_warning_threshold``, at most once per
     ``DefectSystem`` instance. A dedicated ``PyScFermiWarning`` subclass, so it
     can be filtered on its own or together with other py-sc-fermi warnings.
     """

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -1127,6 +1127,33 @@ class TestDefectSystemElementPools(unittest.TestCase):
         total_mg = sum(concs[cs] for cs in system.defect_species[0].charge_states)
         self.assertAlmostEqual(total_mg, target, places=6)
 
+    def test_element_chemical_potential_shifts_solves_once_via_cached_result(self):
+        # Unlike the no-pool case, this system actually reaches the rewired
+        # `self.result.fermi_energy` line inside
+        # element_chemical_potential_shifts, so it pins that a pooled system's
+        # shift read-out costs no additional solve beyond the one `result`
+        # already cached.
+        target = 5.0
+        system = DefectSystem(
+            defect_species=[self.species],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+            element_pools={"Mg": ElementPool(target=target, members={self.species: 1.0})},
+            occupancy_warning_threshold=None,
+        )
+        calls = {"n": 0}
+        original = system.get_sc_fermi
+
+        def counting():
+            calls["n"] += 1
+            return original()
+
+        system.get_sc_fermi = counting
+        _ = system.result
+        _ = system.element_chemical_potential_shifts()
+        self.assertEqual(calls["n"], 1)
+
     def test_element_pool_negative_target_solves(self):
         # Negative net-content target with a negative stoichiometry (net removal):
         # content = -1 * total, so a target of -5 drives the total to 5.
@@ -3515,6 +3542,23 @@ class TestDiluteLimitWarning(unittest.TestCase):
             label="O-rich",
         )
         self.assertEqual(system.result.label, "O-rich")
+
+    def test_read_outs_solve_once_via_cached_result(self):
+        system = self._make_system(
+            [self._saturating_species("S")], occupancy_warning_threshold=None
+        )
+        calls = {"n": 0}
+        original = system.get_sc_fermi
+
+        def counting():
+            calls["n"] += 1
+            return original()
+
+        system.get_sc_fermi = counting
+        _ = system.result
+        _ = system.site_percentages()
+        _ = system.element_chemical_potential_shifts()
+        self.assertEqual(calls["n"], 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -2527,6 +2527,13 @@ class TestDefectSystemFactory(unittest.TestCase):
         system = factory.at(300, convergence_tolerance=1e-12)
         self.assertEqual(system.convergence_tolerance, 1e-12)
 
+    def test_at_forwards_label_from_factory(self):
+        factory = DefectSystemFactory(
+            defect_species=[self.species], dos=self.dos, volume=100, label="O-rich"
+        )
+        system = factory.at(300)
+        self.assertEqual(system.label, "O-rich")
+
     def test_at_with_formation_energy_correction_fns_per_charge_state(self):
         cs_a = DefectChargeState(charge=1, energy=0.5, degeneracy=1, name="X_i_1+_a")
         cs_b = DefectChargeState(charge=1, energy=0.9, degeneracy=1, name="X_i_1+_b")
@@ -3433,6 +3440,28 @@ class TestDiluteLimitWarning(unittest.TestCase):
             [self._saturating_species("S")], occupancy_warning_threshold=0.5
         )
         self.assertNotIn("occupancy_warning_threshold", system.as_dict())
+
+    def test_label_defaults_to_none_and_is_readable(self):
+        system = self._make_system([self._saturating_species("S")])
+        self.assertIsNone(system.label)
+
+    def test_label_is_stored(self):
+        system = self._make_system(
+            [self._saturating_species("S")], label="O-rich"
+        )
+        self.assertEqual(system.label, "O-rich")
+
+    def test_label_round_trips_through_as_dict(self):
+        system = self._make_system(
+            [self._saturating_species("S")], label="O-rich"
+        )
+        self.assertEqual(system.as_dict()["label"], "O-rich")
+        reloaded = DefectSystem.from_dict(system.as_dict())
+        self.assertEqual(reloaded.label, "O-rich")
+
+    def test_label_absent_from_as_dict_when_unset(self):
+        system = self._make_system([self._saturating_species("S")])
+        self.assertNotIn("label", system.as_dict())
 
 
 if __name__ == "__main__":

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -3336,6 +3336,19 @@ class TestDiluteLimitWarning(unittest.TestCase):
             system.get_sc_fermi()  # re-reaches the chokepoint from a different line
         self.assertEqual(len(self._dilute_warnings(records)), 1)
 
+    def test_escalated_dilute_warning_raises_on_every_read(self):
+        # Under an "error" filter the warn call raises, so the latch must arm
+        # only after a delivered warning. Arming it first would swallow the
+        # escalation on a retry, silently handing back the non-physical
+        # dilute-limit numbers, so both solves must raise.
+        system = self._make_system([self._saturating_species("S")])
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DiluteLimitWarning)
+            with self.assertRaises(DiluteLimitWarning):
+                system.get_sc_fermi()
+            with self.assertRaises(DiluteLimitWarning):
+                system.get_sc_fermi()
+
     def test_threshold_absent_from_as_dict(self):
         system = self._make_system(
             [self._saturating_species("S")], occupancy_warning_threshold=0.5
@@ -3405,6 +3418,20 @@ class TestDiluteLimitWarning(unittest.TestCase):
         dilute = self._dilute_warnings(records)
         self.assertEqual(len(dilute), 1)
         # attributed to this test file, not functools.py or defect_system.py
+        self.assertEqual(
+            os.path.basename(dilute[0].filename), os.path.basename(__file__)
+        )
+
+    def test_site_percentages_warning_is_attributed_to_caller(self):
+        # site_percentages solves through the result property -- a deeper first
+        # access than a direct result read -- so this pins the depth-adaptive
+        # stacklevel that keeps the warning blamed on the caller's frame.
+        system = self._make_system([self._saturating_species("S")])
+        with warnings.catch_warnings(record=True) as records:
+            warnings.simplefilter("always")
+            _ = system.site_percentages()
+        dilute = self._dilute_warnings(records)
+        self.assertEqual(len(dilute), 1)
         self.assertEqual(
             os.path.basename(dilute[0].filename), os.path.basename(__file__)
         )

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -3463,6 +3463,59 @@ class TestDiluteLimitWarning(unittest.TestCase):
         system = self._make_system([self._saturating_species("S")])
         self.assertNotIn("label", system.as_dict())
 
+    def test_result_matches_get_sc_fermi_and_carriers(self):
+        system = self._make_system(
+            [self._saturating_species("S")], occupancy_warning_threshold=None
+        )
+        e_fermi, _ = system.get_sc_fermi()
+        p0, n0 = system.dos.carrier_concentrations(e_fermi, system.temperature)
+        result = system.result
+        self.assertEqual(result.fermi_energy, e_fermi)
+        self.assertEqual(result.temperature, system.temperature)
+        self.assertEqual(result.volume, system.volume)
+        self.assertEqual(result.p0_per_cell, float(p0))
+        self.assertEqual(result.n0_per_cell, float(n0))
+
+    def test_result_is_cached(self):
+        system = self._make_system(
+            [self._saturating_species("S")], occupancy_warning_threshold=None
+        )
+        self.assertIs(system.result, system.result)
+
+    def test_result_concentrations_match_global_defect_concs(self):
+        system = self._make_system(
+            [self._saturating_species("S")], occupancy_warning_threshold=None
+        )
+        e_fermi = system.result.fermi_energy
+        raw = system._global_defect_concs(e_fermi)  # dict[DefectChargeState, float]
+        per_cell = system.result.charge_state_concentrations_per_cell
+        for ds in system.defect_species:
+            for cs in ds.charge_states:
+                self.assertEqual(per_cell[ds.name][cs.name], float(raw[cs]))
+
+    def test_result_warning_is_attributed_to_caller(self):
+        # The DiluteLimitWarning must blame the user's frame, not functools or
+        # the library. This pins the manual-cache property (a cached_property
+        # would insert a functools frame and misattribute the warning).
+        system = self._make_system([self._saturating_species("S")])
+        with warnings.catch_warnings(record=True) as records:
+            warnings.simplefilter("always")
+            _ = system.result
+        dilute = self._dilute_warnings(records)
+        self.assertEqual(len(dilute), 1)
+        # attributed to this test file, not functools.py or defect_system.py
+        self.assertEqual(
+            os.path.basename(dilute[0].filename), os.path.basename(__file__)
+        )
+
+    def test_result_carries_the_system_label(self):
+        system = self._make_system(
+            [self._saturating_species("S")],
+            occupancy_warning_threshold=None,
+            label="O-rich",
+        )
+        self.assertEqual(system.result.label, "O-rich")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -122,6 +122,7 @@ class TestDefectSystem(unittest.TestCase):
             "defect_species": [],
             "site_pools": {},
             "element_pools": {},
+            "occupancy_warning_threshold": 0.5,
         }
         for name, value in new_values.items():
             with self.subTest(attribute=name):
@@ -137,16 +138,6 @@ class TestDefectSystem(unittest.TestCase):
         self.assertTrue(self.defect_system.rigid_shift)
         self.assertEqual(self.defect_system.site_pools, {})
         self.assertEqual(self.defect_system.element_pools, {})
-
-    def test_occupancy_warning_threshold_setter_validates(self):
-        with self.assertRaises(ValueError):
-            self.defect_system.occupancy_warning_threshold = 1.5
-
-    def test_occupancy_warning_threshold_is_settable(self):
-        self.defect_system.occupancy_warning_threshold = 0.5
-        self.assertEqual(self.defect_system.occupancy_warning_threshold, 0.5)
-        self.defect_system.occupancy_warning_threshold = None
-        self.assertIsNone(self.defect_system.occupancy_warning_threshold)
 
     def test_total_defect_charge_contributions(self):
         cs_pos = DefectChargeState(charge=1, fixed_concentration=2)
@@ -3319,29 +3310,6 @@ class TestDiluteLimitWarning(unittest.TestCase):
             _ = system.result  # solves; warns once, arms the once-guard
             system.get_sc_fermi()  # re-reaches the chokepoint from a different line
         self.assertEqual(len(self._dilute_warnings(records)), 1)
-
-    def test_changing_threshold_re_arms_warning_for_next_solve(self):
-        # The once-per-instance guard silences repeat warnings for a solved
-        # system. Changing the threshold re-arms it so the next solve warns
-        # again; re-setting the same value leaves it silent.
-        system = self._make_system([self._saturating_species("S")])
-
-        with warnings.catch_warnings(record=True) as first:
-            warnings.simplefilter("always")
-            system.get_sc_fermi()
-        self.assertEqual(len(self._dilute_warnings(first)), 1)
-
-        system.occupancy_warning_threshold = 0.5
-        with warnings.catch_warnings(record=True) as after_change:
-            warnings.simplefilter("always")
-            system.get_sc_fermi()
-        self.assertEqual(len(self._dilute_warnings(after_change)), 1)
-
-        system.occupancy_warning_threshold = 0.5
-        with warnings.catch_warnings(record=True) as after_same:
-            warnings.simplefilter("always")
-            system.get_sc_fermi()
-        self.assertEqual(self._dilute_warnings(after_same), [])
 
     def test_threshold_absent_from_as_dict(self):
         system = self._make_system(

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -3409,6 +3409,21 @@ class TestDiluteLimitWarning(unittest.TestCase):
             os.path.basename(dilute[0].filename), os.path.basename(__file__)
         )
 
+    def test_result_per_cell_concentrations_are_read_only(self):
+        # result caches one object, so a mutable nested dict would let a caller
+        # corrupt the cache in place. Both nesting levels are read-only proxies,
+        # so inner and outer assignment both raise.
+        system = self._make_system(
+            [self._saturating_species("S")], occupancy_warning_threshold=None
+        )
+        per_cell = system.result.charge_state_concentrations_per_cell
+        sp = next(iter(per_cell))
+        cs = next(iter(per_cell[sp]))
+        with self.assertRaises(TypeError):
+            per_cell[sp][cs] = 999.0
+        with self.assertRaises(TypeError):
+            per_cell[sp] = {}
+
     def test_result_carries_the_system_label(self):
         system = self._make_system(
             [self._saturating_species("S")],

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -3,9 +3,7 @@ import math
 import os
 import unittest
 import warnings
-from contextlib import redirect_stdout
-from io import StringIO
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import numpy as np
 import yaml
@@ -307,82 +305,7 @@ class TestDefectSystem(unittest.TestCase):
             {"v_O": [[1, 1], [2, 2]], "O_i": [[1, 1], [2, 2]]},
         )
 
-    def test_concentration_dict(self):
-        cs_v_O = DefectChargeState(charge=1, fixed_concentration=1)
-        cs_O_i = DefectChargeState(charge=-1, fixed_concentration=1)
-        self.defect_system.get_sc_fermi = Mock(return_value=[1, {}])
-        self.defect_system.dos.carrier_concentrations = Mock(return_value=(1, 1))
-        self.defect_system.defect_species[0].get_concentration = Mock(return_value=1)
-        self.defect_system.defect_species[1].get_concentration = Mock(return_value=1)
-        self.defect_system.defect_species[0].charge_state_concentrations = Mock(
-            return_value=[(cs_v_O, 1)]
-        )
-        self.defect_system.defect_species[1].charge_state_concentrations = Mock(
-            return_value=[(cs_O_i, 1)]
-        )
-        self.defect_system.defect_species[0].charge_states = [cs_v_O]
-        self.defect_system.defect_species[1].charge_states = [cs_O_i]
-        self.defect_system.defect_species[0].fixed_concentration = None
-        self.defect_system.defect_species[1].fixed_concentration = None
-        self.defect_system.defect_species[0].nsites = 1
-        self.defect_system.defect_species[1].nsites = 1
-        self.defect_system.defect_species[0].name = "v_O"
-        self.defect_system.defect_species[1].name = "O_i"
-
-        expected_dict = {
-            "Fermi Energy": 1.0,
-            "p0": 1.0e22,
-            "n0": 1.0e22,
-            "v_O": 1.0e22,
-            "O_i": 1.0e22
-        }
-        result_dict = self.defect_system.concentration_dict()
-        self.assertEqual(result_dict, expected_dict)
-
-        # unnamed states -> charge-default names "q+1", "q-1"
-        expected_decomposed_dict = {
-            "Fermi Energy": 1.0,
-            "p0": 1.0e22,
-            "n0": 1.0e22,
-            "v_O": {"q+1": 1.0e22},
-            "O_i": {"q-1": 1.0e22}
-        }
-        result_decomposed_dict = self.defect_system.concentration_dict(decomposed=True)
-        self.assertEqual(result_decomposed_dict, expected_decomposed_dict)
-
-
-
-    def test_charge_state_concentration_dict(self):
-        cs_v_O = DefectChargeState(charge=1, fixed_concentration=1)
-        cs_O_i = DefectChargeState(charge=-1, fixed_concentration=1)
-        self.defect_system.get_sc_fermi = Mock(return_value=[1, {}])
-        self.defect_system.defect_species[0].charge_states = [cs_v_O]
-        self.defect_system.defect_species[1].charge_states = [cs_O_i]
-        self.defect_system.defect_species[0].fixed_concentration = None
-        self.defect_system.defect_species[1].fixed_concentration = None
-        self.defect_system.defect_species[0].nsites = 1
-        self.defect_system.defect_species[1].nsites = 1
-        self.defect_system.defect_species[0].name = "v_O"
-        self.defect_system.defect_species[1].name = "O_i"
-
-        result = self.defect_system.charge_state_concentration_dict()
-        self.assertEqual(list(result.keys()), ["v_O", "O_i"])
-        # unnamed state at charge +1 -> charge-default name "q+1"
-        self.assertAlmostEqual(result["v_O"]["q+1"], 1e22)
-
-    def test_charge_state_concentration_dict_named(self):
-        cs_v_O = DefectChargeState(charge=1, fixed_concentration=1, name="v_O_1+")
-        self.defect_system.get_sc_fermi = Mock(return_value=[1, {}])
-        self.defect_system.defect_species[0].charge_states = [cs_v_O]
-        self.defect_system.defect_species[0].fixed_concentration = None
-        self.defect_system.defect_species[0].nsites = 1
-        self.defect_system.defect_species[0].name = "v_O"
-
-        result = self.defect_system.charge_state_concentration_dict()
-        self.assertIn("v_O_1+", result["v_O"])
-        self.assertAlmostEqual(result["v_O"]["v_O_1+"], 1e22)
-
-    def test_charge_state_concentration_dict_metastable_named(self):
+    def test_named_metastable_states_are_reported_separately(self):
         # Named metastable states use their names as keys.
         cs_a = DefectChargeState(charge=0, fixed_concentration=0.6, name="V_O_tet")
         cs_b = DefectChargeState(charge=0, fixed_concentration=0.4, name="V_O_oct")
@@ -392,26 +315,11 @@ class TestDefectSystem(unittest.TestCase):
         dos.nelect = 10
         system = DefectSystem(defect_species=[ds], volume=1.0, dos=dos, temperature=300)
         system.get_sc_fermi = Mock(return_value=[0.5, {}])
-
-        result = system.charge_state_concentration_dict(per_volume=False)
-        self.assertAlmostEqual(result["V_O"]["V_O_tet"], 0.6)
-        self.assertAlmostEqual(result["V_O"]["V_O_oct"], 0.4)
-
-    def test_decomposed_concentration_dict_does_not_sum_metastable_states(self):
-        cs_a = DefectChargeState(charge=0, fixed_concentration=0.6, name="V_O_a")
-        cs_b = DefectChargeState(charge=0, fixed_concentration=0.4, name="V_O_b")
-        ds = DefectSpecies(name="V_O", nsites=1, charge_states=[cs_a, cs_b])
-        dos = Mock(spec=DOS)
-        dos.bandgap = 1.0
-        dos.nelect = 10
-        system = DefectSystem(defect_species=[ds], volume=1.0, dos=dos, temperature=300)
-        system.get_sc_fermi = Mock(return_value=[0.5, {}])
         system.dos.carrier_concentrations = Mock(return_value=(1, 1))
 
-        result = system.concentration_dict(decomposed=True, per_volume=False)["V_O"]
-        self.assertEqual(set(result), {"V_O_a", "V_O_b"})
-        self.assertAlmostEqual(result["V_O_a"], 0.6)
-        self.assertAlmostEqual(result["V_O_b"], 0.4)
+        result = system.result.charge_state_concentrations_per_cell["V_O"]
+        self.assertAlmostEqual(result["V_O_tet"], 0.6)
+        self.assertAlmostEqual(result["V_O_oct"], 0.4)
 
     def test_metastable_boltzmann_concentration_ratio(self):
         # Two variable-concentration states sharing a charge: their solved
@@ -424,27 +332,12 @@ class TestDefectSystem(unittest.TestCase):
         dos.nelect = 10
         system = DefectSystem(defect_species=[ds], volume=1.0, dos=dos, temperature=300)
         system.get_sc_fermi = Mock(return_value=[0.5, {}])
+        system.dos.carrier_concentrations = Mock(return_value=(1, 1))
 
-        result = system.charge_state_concentration_dict(per_volume=False)["V_O"]
+        result = system.result.charge_state_concentrations_per_cell["V_O"]
         ratio = result["V_O_a"] / result["V_O_b"]
         expected = np.exp((1.2 - 1.0) / (kboltz * 300))
         self.assertAlmostEqual(ratio / expected, 1.0, places=8)
-
-    def test_decomposed_dict_agrees_with_charge_state_concentration_dict(self):
-        cs_a = DefectChargeState(charge=0, energy=1.0, name="V_O_a")
-        cs_b = DefectChargeState(charge=0, energy=1.2, name="V_O_b")
-        cs_c = DefectChargeState(charge=2, energy=0.5)
-        ds = DefectSpecies(name="V_O", nsites=1, charge_states=[cs_a, cs_b, cs_c])
-        dos = Mock(spec=DOS)
-        dos.bandgap = 1.0
-        dos.nelect = 10
-        system = DefectSystem(defect_species=[ds], volume=1.0, dos=dos, temperature=300)
-        system.get_sc_fermi = Mock(return_value=[0.5, {}])
-        system.dos.carrier_concentrations = Mock(return_value=(1, 1))
-
-        decomposed = system.concentration_dict(decomposed=True, per_volume=False)
-        per_state = system.charge_state_concentration_dict(per_volume=False)
-        self.assertEqual(decomposed["V_O"], per_state["V_O"])
 
     def test__repr__(self):
         dos = Mock(spec=DOS)
@@ -757,7 +650,8 @@ class TestDefectSystemSitePools(unittest.TestCase):
         # charge state directly fixed.
         by_pair_key = self._two_state_system({("X", "X_a"): 0.25})
         by_pair_key.get_sc_fermi = Mock(return_value=[0.5, {}])
-        via_pair_key = by_pair_key.charge_state_concentration_dict(per_volume=False)
+        by_pair_key.dos.carrier_concentrations = Mock(return_value=(1, 1))
+        via_pair_key = by_pair_key.result.charge_state_concentrations_per_cell
 
         cs_a = DefectChargeState(charge=0, energy=1.0, name="X_a", fixed_concentration=0.25)
         cs_b = DefectChargeState(charge=1, energy=1.5, name="X_b")
@@ -772,8 +666,9 @@ class TestDefectSystemSitePools(unittest.TestCase):
             temperature=300,
         )
         by_direct_construction.get_sc_fermi = Mock(return_value=[0.5, {}])
-        via_direct_construction = by_direct_construction.charge_state_concentration_dict(
-            per_volume=False
+        by_direct_construction.dos.carrier_concentrations = Mock(return_value=(1, 1))
+        via_direct_construction = (
+            by_direct_construction.result.charge_state_concentrations_per_cell
         )
 
         self.assertEqual(via_pair_key, via_direct_construction)
@@ -893,10 +788,10 @@ class TestDefectSystemSitePercentages(unittest.TestCase):
         self.assertLessEqual(pct, 100.0)
         self.assertGreater(pct, 99.0)
 
-    def test_site_percentages_agree_with_concentration_dict(self):
+    def test_site_percentages_agree_with_result_concentrations(self):
         # The documented contract: site_percentages reports the same solved
-        # concentrations as concentration_dict, just as an occupancy fraction.
-        # Comparing the two public methods pins that contract without
+        # concentrations as result.concentrations_per_cell, just as an occupancy
+        # fraction. Comparing the two public read-outs pins that contract without
         # duplicating the internal formula.
         species = DefectSpecies(
             "R",
@@ -913,7 +808,7 @@ class TestDefectSystemSitePercentages(unittest.TestCase):
             temperature=300,
             occupancy_warning_threshold=None,
         )
-        per_cell = system.concentration_dict(decomposed=False, per_volume=False)
+        per_cell = system.result.concentrations_per_cell
         expected = per_cell["R"] / species.nsites * 100
         self.assertAlmostEqual(system.site_percentages()["R"], expected, places=8)
 
@@ -1004,7 +899,7 @@ class TestDefectSystemSitePercentages(unittest.TestCase):
             site_pools={"shared": SitePool(n_sites=4.0, species=[pooled])},
             occupancy_warning_threshold=None,
         )
-        per_cell = system.concentration_dict(decomposed=False, per_volume=False)
+        per_cell = system.result.concentrations_per_cell
         pct = system.site_percentages()
         # P's own nsites is 5, but as a pool member its denominator is the
         # pool size 4.0; U falls back to its own nsites 3.
@@ -1446,13 +1341,13 @@ class TestDefectSystemElementPools(unittest.TestCase):
         self.assertGreater(above.element_chemical_potential_shifts()["X"], 0.0)
         self.assertLess(below.element_chemical_potential_shifts()["X"], 0.0)
 
-    def test_shift_reproduces_concentration_dict_content(self):
+    def test_shift_reproduces_result_concentrations(self):
         # Convert the reported delta_mu back to the activity
         # lambda = exp(delta_mu / kT) and feed it through the site-exclusion
-        # formula: it must reproduce the species content concentration_dict
+        # formula: it must reproduce the species content the result read-out
         # reports at the same solved Fermi level. An independent check of the
         # eV magnitude and of the documented consistency with
-        # concentration_dict.
+        # result.concentrations_per_cell.
         nsites, energy, degeneracy, target, temperature = 10, 1.0, 1, 1e-3, 300
         sp = DefectSpecies(
             "S",
@@ -1474,9 +1369,9 @@ class TestDefectSystemElementPools(unittest.TestCase):
         activity = w * math.exp(delta_mu / (kboltz * temperature))
         content_from_shift = nsites * activity / (1 + activity)
 
-        content_from_dict = system.concentration_dict(per_volume=False)["S"]
-        self.assertAlmostEqual(content_from_shift, content_from_dict, places=10)
-        self.assertAlmostEqual(content_from_dict, target, places=6)
+        content_from_result = system.result.concentrations_per_cell["S"]
+        self.assertAlmostEqual(content_from_shift, content_from_result, places=10)
+        self.assertAlmostEqual(content_from_result, target, places=6)
 
     def test_no_element_pools_returns_empty_dict(self):
         system = DefectSystem(
@@ -2355,7 +2250,8 @@ class TestDefectSystemBandEdgeCorrections(unittest.TestCase):
             formation_energy_corrections=corrections_for(cs_a, cs_b),
         )
         system.get_sc_fermi = Mock(return_value=[0.5, {}])
-        return system.charge_state_concentration_dict(per_volume=False)["X"]
+        system.dos.carrier_concentrations = Mock(return_value=(1, 1))
+        return system.result.charge_state_concentrations_per_cell["X"]
 
     def test_formation_energy_corrections_accept_name_pairs(self):
         by_object = self._corrected_x_concentrations(lambda cs_a, cs_b: {cs_a: 0.2})
@@ -2593,7 +2489,8 @@ class TestDefectSystemFactory(unittest.TestCase):
         )
         system = factory.at(300)
         system.get_sc_fermi = Mock(return_value=[0.5, {}])
-        return system.charge_state_concentration_dict(per_volume=False)["X"]
+        system.dos.carrier_concentrations = Mock(return_value=(1, 1))
+        return system.result.charge_state_concentrations_per_cell["X"]
 
     def test_factory_correction_fns_accept_name_pairs(self):
         by_object = self._factory_corrected_x_concentrations(
@@ -2645,7 +2542,7 @@ class TestDefectSystemFactory(unittest.TestCase):
         self.assertAlmostEqual(factory.dos.bandgap, 2.0)
 
 
-class TestDefectSystemReport(unittest.TestCase):
+class TestDefectSystemResultString(unittest.TestCase):
     def setUp(self):
         self.dos = semiconducting_dos(bandgap=2.0, nelect=10)
         self.species = DefectSpecies(
@@ -2657,36 +2554,18 @@ class TestDefectSystemReport(unittest.TestCase):
             ],
         )
 
-    def test_report_contains_expected_sections(self):
+    def test_result_string_contains_expected_sections(self):
         system = DefectSystem(
             defect_species=[self.species], dos=self.dos, volume=100, temperature=300
         )
-        with patch("sys.stdout", new=StringIO()):
-            output = system.report()
+        output = str(system.result)
         for snippet in (
-            "DefectSystem",
             "SC Fermi energy:",
             "Carriers:",
             "Defect concentrations:",
             "V_O",
         ):
             self.assertIn(snippet, output)
-
-    def test_report_shows_single_corrected_bandgap_value(self):
-        system = DefectSystem(
-            defect_species=[self.species],
-            dos=self.dos,
-            volume=100,
-            temperature=300,
-            vbm_shift=0.05,
-            cbm_shift=-0.02,
-            occupancy_warning_threshold=None,
-        )
-        with patch("sys.stdout", new=StringIO()):
-            output = system.report()
-        self.assertIn("1.93", output)
-        self.assertNotIn("→", output)
-        self.assertAlmostEqual(system.dos.bandgap, 1.93)  # DOS scissored once
 
 
 class TestDefectSystemPoolSerialisation(unittest.TestCase):
@@ -2986,7 +2865,7 @@ class TestDefectSystemFixedConcentrations(unittest.TestCase):
             fixed_concentrations={"X": 0.01},
         )
         self.assertAlmostEqual(
-            system.concentration_dict(per_volume=False)["X"], 0.01
+            system.result.concentrations_per_cell["X"], 0.01
         )
         self.assertEqual(system.defect_species_by_name("X").fixed_concentration, 0.01)
 
@@ -2996,7 +2875,7 @@ class TestDefectSystemFixedConcentrations(unittest.TestCase):
         )
         system = factory.at(300, fixed_concentrations={"X": 0.01})
         self.assertAlmostEqual(
-            system.concentration_dict(per_volume=False)["X"], 0.01
+            system.result.concentrations_per_cell["X"], 0.01
         )
         self.assertEqual(system.defect_species_by_name("X").fixed_concentration, 0.01)
 
@@ -3032,18 +2911,23 @@ class TestDefectSystemFixedConcentrations(unittest.TestCase):
         )
         T_high, T_low = 1000, 300
 
-        high = factory.at(T_high).concentration_dict(per_volume=False)
+        high = factory.at(T_high).result
+        frozen_high = high.concentrations_per_cell["X_frozen"]
         low = factory.at(
-            T_low, fixed_concentrations={"X_frozen": high["X_frozen"]}
-        ).concentration_dict(per_volume=False)
+            T_low, fixed_concentrations={"X_frozen": frozen_high}
+        ).result
 
         # the frozen species keeps its high-temperature total
         self.assertAlmostEqual(
-            low["X_frozen"], high["X_frozen"], delta=abs(high["X_frozen"]) * 1e-9
+            low.concentrations_per_cell["X_frozen"],
+            frozen_high,
+            delta=abs(frozen_high) * 1e-9,
         )
         # a non-frozen species and the carriers re-equilibrate
-        self.assertNotAlmostEqual(low["D"], high["D"])
-        self.assertNotAlmostEqual(low["n0"], high["n0"])
+        self.assertNotAlmostEqual(
+            low.concentrations_per_cell["D"], high.concentrations_per_cell["D"]
+        )
+        self.assertNotAlmostEqual(low.n0_per_cell, high.n0_per_cell)
 
     def test_fix_on_one_call_does_not_leak_to_another_or_to_the_factory(self):
         species = self._donor("X")
@@ -3057,10 +2941,10 @@ class TestDefectSystemFixedConcentrations(unittest.TestCase):
         # the un-fixed call is unaffected by the earlier fixed call
         self.assertIsNone(free.defect_species_by_name("X").fixed_concentration)
         self.assertNotAlmostEqual(
-            free.concentration_dict(per_volume=False)["X"], 0.01
+            free.result.concentrations_per_cell["X"], 0.01
         )
         self.assertAlmostEqual(
-            fixed.concentration_dict(per_volume=False)["X"], 0.01
+            fixed.result.concentrations_per_cell["X"], 0.01
         )
         # the factory's own species object is never mutated
         self.assertIsNone(species.fixed_concentration)
@@ -3091,7 +2975,7 @@ class TestDefectSystemFixedConcentrations(unittest.TestCase):
         self.assertAlmostEqual(system.defect_species[0].charge_states[1].energy, 0.85)
         # and the fix (resolved by name) is in effect
         self.assertAlmostEqual(
-            system.concentration_dict(per_volume=False)["X_i"], 0.02
+            system.result.concentrations_per_cell["X_i"], 0.02
         )
 
     def test_unknown_species_name_raises_value_error_naming_it(self):
@@ -3161,7 +3045,7 @@ class TestDefectSystemFixedConcentrations(unittest.TestCase):
         )
         self.assertEqual(system.defect_species_by_name("X").fixed_concentration, 0.01)
         self.assertAlmostEqual(
-            system.concentration_dict(per_volume=False)["X"], 0.01
+            system.result.concentrations_per_cell["X"], 0.01
         )
 
     def test_fixes_multiple_species_in_one_call(self):
@@ -3173,7 +3057,7 @@ class TestDefectSystemFixedConcentrations(unittest.TestCase):
             fixed_concentrations={"X": 0.01, "Y": 0.02},
             occupancy_warning_threshold=None,
         )
-        cd = system.concentration_dict(per_volume=False)
+        cd = system.result.concentrations_per_cell
         self.assertAlmostEqual(cd["X"], 0.01)
         self.assertAlmostEqual(cd["Y"], 0.02)
 
@@ -3424,19 +3308,16 @@ class TestDiluteLimitWarning(unittest.TestCase):
         self.assertIn(f"{pool_pct:.3g}%", str(dilute[0].message))
 
     def test_warns_at_most_once_per_system_under_default_filter(self):
-        # Inspecting one solved system several ways reaches the chokepoint at
-        # different stack depths; under the realistic default filter (not
-        # "always") that would defeat location-based de-duplication, so the
-        # once-per-instance guard is what holds this to a single warning.
+        # Two paths re-reach the high-occupancy chokepoint from different source
+        # locations: the result solve and a direct get_sc_fermi call. Under the
+        # realistic "default" filter (not "always") those distinct locations would
+        # escape location-based de-duplication, so the once-per-instance guard is
+        # what holds this to a single warning.
         system = self._make_system([self._saturating_species("S")])
-        with warnings.catch_warnings(record=True) as records, redirect_stdout(
-            StringIO()
-        ):
+        with warnings.catch_warnings(record=True) as records:
             warnings.simplefilter("default")
-            system.report()
-            system.site_percentages()
-            system.concentration_dict()
-            system.get_sc_fermi()
+            _ = system.result  # solves; warns once, arms the once-guard
+            system.get_sc_fermi()  # re-reaches the chokepoint from a different line
         self.assertEqual(len(self._dilute_warnings(records)), 1)
 
     def test_changing_threshold_re_arms_warning_for_next_solve(self):

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -2829,6 +2829,31 @@ class TestDefectSystemPoolSerialisation(unittest.TestCase):
         )
         yaml.safe_dump(system.as_dict())
 
+    def test_fully_numpy_system_result_as_dict_is_yaml_safe(self):
+        # The same boundary guard for the solved-state read-out. The cm^-3 views
+        # scale per-cell values by 1e24/volume, so a numpy volume or temperature
+        # leaks numpy scalars into result.as_dict() unless the result casts them.
+        species = DefectSpecies(
+            "Z",
+            nsites=np.int64(4),
+            charge_states=[
+                DefectChargeState(
+                    charge=np.int64(0),
+                    energy=np.float64(0.5),
+                    degeneracy=np.float64(1),
+                ),
+            ],
+        )
+        system = DefectSystem(
+            defect_species=[species],
+            dos=self.dos,
+            volume=np.float64(100.0),
+            temperature=np.float64(300.0),
+            convergence_tolerance=np.float64(1e-8),
+            occupancy_warning_threshold=None,
+        )
+        yaml.safe_dump(system.result.as_dict())
+
 
 class TestDefectSystemFixedConcentrations(unittest.TestCase):
     def setUp(self):

--- a/tests/test_defect_system_result.py
+++ b/tests/test_defect_system_result.py
@@ -1,0 +1,68 @@
+import unittest
+from dataclasses import FrozenInstanceError
+
+from py_sc_fermi.defect_system_result import DefectSystemResult
+
+
+class DefectSystemResultViewsTestCase(unittest.TestCase):
+    def _result(self, volume=100.0, label=None):
+        return DefectSystemResult(
+            temperature=300.0,
+            fermi_energy=0.5,
+            volume=volume,
+            label=label,
+            p0_per_cell=2.0,
+            n0_per_cell=4.0,
+            charge_state_concentrations_per_cell={
+                "V_O": {"q+2": 1.0, "q0": 3.0},
+                "Ti_i": {"q+4": 5.0},
+            },
+        )
+
+    def test_per_cell_fields_stored_verbatim(self):
+        r = self._result()
+        self.assertEqual(r.p0_per_cell, 2.0)
+        self.assertEqual(r.n0_per_cell, 4.0)
+        self.assertEqual(
+            r.charge_state_concentrations_per_cell["V_O"], {"q+2": 1.0, "q0": 3.0}
+        )
+
+    def test_cm3_views_scale_per_cell_by_1e24_over_volume(self):
+        r = self._result(volume=100.0)
+        scale = 1e24 / 100.0
+        self.assertEqual(r.p0, 2.0 * scale)
+        self.assertEqual(r.n0, 4.0 * scale)
+        self.assertEqual(
+            r.charge_state_concentrations,
+            {
+                "V_O": {"q+2": 1.0 * scale, "q0": 3.0 * scale},
+                "Ti_i": {"q+4": 5.0 * scale},
+            },
+        )
+
+    def test_concentrations_per_cell_are_species_totals(self):
+        r = self._result()
+        self.assertEqual(r.concentrations_per_cell, {"V_O": 4.0, "Ti_i": 5.0})
+
+    def test_concentrations_equal_summed_breakdown_in_cm3(self):
+        r = self._result(volume=100.0)
+        scale = 1e24 / 100.0
+        self.assertEqual(
+            r.concentrations, {"V_O": 4.0 * scale, "Ti_i": 5.0 * scale}
+        )
+
+    def test_frozen(self):
+        r = self._result()
+        with self.assertRaises(FrozenInstanceError):
+            r.fermi_energy = 0.9
+
+    def test_equal_by_value(self):
+        self.assertEqual(self._result(), self._result())
+
+    def test_unhashable(self):
+        with self.assertRaises(TypeError):
+            hash(self._result())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_defect_system_result.py
+++ b/tests/test_defect_system_result.py
@@ -64,5 +64,59 @@ class DefectSystemResultViewsTestCase(unittest.TestCase):
             hash(self._result())
 
 
+class DefectSystemResultSerialisationTestCase(unittest.TestCase):
+    def _result(self, label=None):
+        return DefectSystemResult(
+            temperature=300.0,
+            fermi_energy=0.5,
+            volume=100.0,
+            label=label,
+            p0_per_cell=2.0,
+            n0_per_cell=4.0,
+            charge_state_concentrations_per_cell={"V_O": {"q+2": 1.0, "q0": 3.0}},
+        )
+
+    def test_as_dict_shape_keys_and_units(self):
+        d = self._result(label="O-rich").as_dict()
+        scale = 1e24 / 100.0
+        self.assertEqual(
+            set(d),
+            {
+                "fermi_energy",
+                "p0",
+                "n0",
+                "temperature",
+                "volume",
+                "label",
+                "concentrations",
+                "charge_state_concentrations",
+            },
+        )
+        self.assertEqual(d["fermi_energy"], 0.5)
+        self.assertEqual(d["p0"], 2.0 * scale)
+        self.assertEqual(d["label"], "O-rich")
+        self.assertEqual(d["concentrations"], {"V_O": 4.0 * scale})
+        self.assertEqual(
+            d["charge_state_concentrations"],
+            {"V_O": {"q+2": 1.0 * scale, "q0": 3.0 * scale}},
+        )
+
+    def test_as_dict_label_is_none_when_unset(self):
+        self.assertIsNone(self._result().as_dict()["label"])
+
+    def test_repr_is_concise(self):
+        text = repr(self._result(label="O-rich"))
+        self.assertIn("DefectSystemResult(", text)
+        self.assertIn("fermi_energy=0.5000 eV", text)
+        self.assertIn("temperature=300 K", text)
+        self.assertIn("label='O-rich'", text)
+        self.assertNotIn("q+2", text)  # concise: no concentration payload
+
+    def test_repr_omits_label_when_unset(self):
+        text = repr(self._result())
+        self.assertIn("DefectSystemResult(", text)
+        self.assertNotIn("label", text)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_defect_system_result.py
+++ b/tests/test_defect_system_result.py
@@ -118,5 +118,42 @@ class DefectSystemResultSerialisationTestCase(unittest.TestCase):
         self.assertNotIn("label", text)
 
 
+class DefectSystemResultStrTestCase(unittest.TestCase):
+    def _result(self):
+        return DefectSystemResult(
+            temperature=300.0,
+            fermi_energy=0.5,
+            volume=100.0,
+            label=None,
+            p0_per_cell=2.0,
+            n0_per_cell=4.0,
+            charge_state_concentrations_per_cell={"V_O": {"q+2": 3.0, "q0": 1.0}},
+        )
+
+    def test_str_reports_solution_only(self):
+        text = str(self._result())
+        # solved-state content is present
+        self.assertIn("SC Fermi energy:  0.500000 eV", text)
+        self.assertIn("Carriers:", text)
+        self.assertIn("V_O", text)
+        self.assertIn("q+2", text)
+        # percentages of the species total (3 of 4 -> 75%, 1 of 4 -> 25%)
+        self.assertIn("75.00%", text)
+        self.assertIn("25.00%", text)
+        # no system-description block leaks in
+        self.assertNotIn("bandgap", text)
+        self.assertNotIn("nsites", text)
+        self.assertNotIn("[fixed]", text)
+
+    def test_str_zero_species_total_shows_zero_percent(self):
+        r = DefectSystemResult(
+            temperature=300.0, fermi_energy=0.5, volume=100.0, label=None,
+            p0_per_cell=2.0, n0_per_cell=4.0,
+            charge_state_concentrations_per_cell={"X": {"q0": 0.0}},
+        )
+        text = str(r)
+        self.assertIn("0.00%", text)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Reads of a solved `DefectSystem` now go through a single cached `DefectSystem.result` (a new `DefectSystemResult`), replacing the flat-dict read-outs `report()`, `concentration_dict()` and `charge_state_concentration_dict()` and their `decomposed`/`per_volume` flags. Closes #86.

## The result object

`DefectSystemResult` holds the solved state: typed scalars (`fermi_energy`, `p0`, `n0`, `temperature`); `concentrations` (per-species totals) and `charge_state_concentrations` (per charge state), in cm^-3 by default, each with a `_per_cell` counterpart. Per-species totals are derived from the per-charge-state breakdown, so the two cannot disagree. `str(result)` is the human-readable report (the solution only; `repr(system)` still describes the system); `as_dict()` is a JSON-safe record with snake_case keys (`fermi_energy`, not `"Fermi Energy"`).

`system.result` solves once on first access and caches. `site_percentages` and `element_chemical_potential_shifts` now read the cached result, so a solved system is solved once.

## Immutability

`occupancy_warning_threshold` becomes construction-only (its setter is removed). With fixing already construction-only, `DefectSystem` is now immutable through every public route, which is what makes the unconditional `result` cache safe.

## label

`DefectSystem` and `DefectSystemFactory` gain an optional `label`, a human-readable tag copied into `result` and serialised when set, for tabulating results across scenarios.

## Docs

Migration guide, tutorial notebook and CHANGELOG updated to the new read-out. A pre-existing Sphinx warning in the `DefectSystemFactory` docstring is fixed in passing.
