### PR TITLE
Make DefectSystem and pool container accessors return read-only views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,14 @@
   solves once on first access and caches the result (it is an immutable
   snapshot). `DefectSystem` and `DefectSystemFactory` also gained an optional
   `label`, a human-readable tag copied into `result` and serialised when set.
+- `DefectSystem` and the pool classes now return read-only views from their
+  container accessors, so the immutable-snapshot contract holds at the
+  container level (previously some accessors leaked live-mutable internals
+  and others returned defensive copies). `DefectSystem.defect_species` and
+  `SitePool.species` return tuples; `DefectSystem.site_pools` /
+  `element_pools` and `ElementPool.members` return read-only mappings. All
+  documented use is read-only, so this is non-breaking; to obtain a mutable
+  copy, wrap explicitly (`list(...)`, `dict(...)`).
 
 ### Bug Fixes
 

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -5,7 +5,7 @@ import math
 import sys
 import warnings
 from collections import Counter
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Any, NamedTuple
@@ -288,12 +288,12 @@ class DefectSystem:
         return self._defect_species
 
     @property
-    def site_pools(self) -> dict[str, SitePool]:
-        return self._site_pools
+    def site_pools(self) -> Mapping[str, SitePool]:
+        return MappingProxyType(self._site_pools)
 
     @property
-    def element_pools(self) -> dict[str, ElementPool]:
-        return self._element_pools
+    def element_pools(self) -> Mapping[str, ElementPool]:
+        return MappingProxyType(self._element_pools)
 
     @property
     def occupancy_warning_threshold(self) -> float | None:

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -5,7 +5,7 @@ import math
 import sys
 import warnings
 from collections import Counter
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Any, NamedTuple
@@ -482,12 +482,12 @@ class DefectSystem:
                     )
         for element, element_pool in self.element_pools.items():
             self._check_unknown_species(
-                "element pool", element, list(element_pool.members), roster
+                "element pool", element, element_pool.members, roster
             )
 
     @staticmethod
     def _check_unknown_species(
-        kind: str, pool_name: str, members: list[str], roster: set[str]
+        kind: str, pool_name: str, members: Iterable[str], roster: set[str]
     ) -> None:
         """Raise if any member name is not in ``roster``."""
         unknown = sorted(set(members) - roster)
@@ -499,7 +499,7 @@ class DefectSystem:
 
     @staticmethod
     def _check_duplicate_species(
-        kind: str, pool_name: str, members: list[str]
+        kind: str, pool_name: str, members: Iterable[str]
     ) -> None:
         """Raise if any member name appears more than once (site pools only)."""
         repeated = sorted(

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -238,7 +238,7 @@ class DefectSystem:
         )
         self._occupancy_warning_emitted = False
 
-        self._defect_species = copy.deepcopy(defect_species)
+        self._defect_species = tuple(copy.deepcopy(defect_species))
         self._site_pools: dict[str, SitePool] = dict(site_pools or {})
         self._element_pools: dict[str, ElementPool] = dict(element_pools or {})
         self._validate_pools()
@@ -284,7 +284,7 @@ class DefectSystem:
         return self._rigid_shift
 
     @property
-    def defect_species(self) -> list[DefectSpecies]:
+    def defect_species(self) -> tuple[DefectSpecies, ...]:
         return self._defect_species
 
     @property

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -721,10 +721,12 @@ class DefectSystem:
         return {
             elem: ResolvedElementPool(
                 target=pool.target,
-                members={
-                    self._resolve_species(name): stoich
-                    for name, stoich in pool.members.items()
-                },
+                members=MappingProxyType(
+                    {
+                        self._resolve_species(name): stoich
+                        for name, stoich in pool.members.items()
+                    }
+                ),
             )
             for elem, pool in self.element_pools.items()
         }

--- a/py_sc_fermi/pools.py
+++ b/py_sc_fermi/pools.py
@@ -194,7 +194,7 @@ class ResolvedElementPool:
     Built internally by ``DefectSystem._resolve_element_pools`` from a validated
     ``ElementPool``; carries no validation of its own. Equality is by identity
     (``eq=False``) -- it is built once and never compared by value, and a
-    synthesised value ``__hash__`` over its ``mapping`` field would raise.
+    synthesised value ``__hash__`` over its ``members`` mapping would raise.
     """
 
     target: float

--- a/py_sc_fermi/pools.py
+++ b/py_sc_fermi/pools.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 
 import math
 from collections import Counter
+from collections.abc import Mapping
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import TypedDict
 
 from py_sc_fermi.defect_species import DefectSpecies
@@ -67,7 +69,7 @@ class SitePool:
         if not species:
             raise ValueError("SitePool must list at least one species.")
         self._n_sites = n_sites
-        self._species: list[str] = species
+        self._species: tuple[str, ...] = tuple(species)
 
     @property
     def n_sites(self) -> float:
@@ -75,9 +77,9 @@ class SitePool:
         return self._n_sites
 
     @property
-    def species(self) -> list[str]:
-        """The pooled species, by name."""
-        return list(self._species)
+    def species(self) -> tuple[str, ...]:
+        """The pooled species, by name (read-only)."""
+        return self._species
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, SitePool):
@@ -158,9 +160,9 @@ class ElementPool:
         return self._target
 
     @property
-    def members(self) -> dict[str, float]:
-        """Mapping of pooled species name to stoichiometry."""
-        return dict(self._members)
+    def members(self) -> Mapping[str, float]:
+        """Mapping of pooled species name to stoichiometry (read-only)."""
+        return MappingProxyType(self._members)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, ElementPool):

--- a/py_sc_fermi/pools.py
+++ b/py_sc_fermi/pools.py
@@ -194,8 +194,8 @@ class ResolvedElementPool:
     Built internally by ``DefectSystem._resolve_element_pools`` from a validated
     ``ElementPool``; carries no validation of its own. Equality is by identity
     (``eq=False``) -- it is built once and never compared by value, and a
-    synthesised value ``__hash__`` over its ``dict`` field would raise.
+    synthesised value ``__hash__`` over its ``mapping`` field would raise.
     """
 
     target: float
-    members: dict[DefectSpecies, float]
+    members: Mapping[DefectSpecies, float]

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -755,6 +755,20 @@ class TestDefectSystemSitePools(unittest.TestCase):
         self.assertIn("dE: 1 per cell", repr(system))
         self.assertIn("A ×2", repr(system))
 
+    def test_site_pools_mapping_is_read_only(self):
+        system = DefectSystem(
+            defect_species=[self.species_a],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+            site_pools={"shared": SitePool(n_sites=10.0, species=[self.species_a])},
+        )
+        key = next(iter(system.site_pools))
+        with self.assertRaises(TypeError):
+            system.site_pools[key] = system.site_pools[key]
+        with self.assertRaises(TypeError):
+            del system.site_pools[key]
+
 
 class TestDefectSystemSitePercentages(unittest.TestCase):
     def setUp(self):
@@ -1484,6 +1498,26 @@ class TestDefectSystemElementPools(unittest.TestCase):
         )
         with self.assertRaises(ElementPoolError):
             system.element_chemical_potential_shifts()
+
+    def test_element_pools_mapping_is_read_only(self):
+        o_i = DefectSpecies(
+            "O_i", nsites=4,
+            charge_states=[DefectChargeState(charge=0, energy=1.0, degeneracy=1)],
+        )
+        v_o = DefectSpecies(
+            "V_O", nsites=4,
+            charge_states=[DefectChargeState(charge=0, energy=1.0, degeneracy=1)],
+        )
+        system = DefectSystem(
+            defect_species=[o_i, v_o],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+            element_pools={"dO": ElementPool(target=0.0, members={o_i: 2.0, "V_O": -3.0})},
+        )
+        key = next(iter(system.element_pools))
+        with self.assertRaises(TypeError):
+            system.element_pools[key] = system.element_pools[key]
 
 
 class TestDefectSystemElementPoolConvergence(unittest.TestCase):

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -1519,6 +1519,28 @@ class TestDefectSystemElementPools(unittest.TestCase):
         with self.assertRaises(TypeError):
             system.element_pools[key] = system.element_pools[key]
 
+    def test_resolved_element_pool_members_are_read_only(self):
+        o_i = DefectSpecies(
+            "O_i", nsites=4,
+            charge_states=[DefectChargeState(charge=0, energy=1.0, degeneracy=1)],
+        )
+        v_o = DefectSpecies(
+            "V_O", nsites=4,
+            charge_states=[DefectChargeState(charge=0, energy=1.0, degeneracy=1)],
+        )
+        system = DefectSystem(
+            defect_species=[o_i, v_o],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+            element_pools={"dO": ElementPool(target=0.0, members={o_i: 2.0, "V_O": -3.0})},
+        )
+        resolved = system._resolve_element_pools()
+        pool = next(iter(resolved.values()))
+        key = next(iter(pool.members))
+        with self.assertRaises(TypeError):
+            pool.members[key] = 1.0
+
 
 class TestDefectSystemElementPoolConvergence(unittest.TestCase):
     """Convergence of the element-pool chemical-potential solve across

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -110,6 +110,14 @@ class TestDefectSystem(unittest.TestCase):
     def test_defect_species_names(self):
         self.assertEqual(self.defect_system.defect_species_names, ["v_O", "O_i"])
 
+    def test_defect_species_is_a_read_only_tuple(self):
+        species = self.defect_system.defect_species
+        self.assertIsInstance(species, tuple)
+        with self.assertRaises(AttributeError):
+            species.append(species[0])
+        with self.assertRaises(TypeError):
+            species[0] = species[0]
+
     def test_public_attributes_are_read_only(self):
         new_values = {
             "volume": 1.0,

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -1500,40 +1500,24 @@ class TestDefectSystemElementPools(unittest.TestCase):
             system.element_chemical_potential_shifts()
 
     def test_element_pools_mapping_is_read_only(self):
-        o_i = DefectSpecies(
-            "O_i", nsites=4,
-            charge_states=[DefectChargeState(charge=0, energy=1.0, degeneracy=1)],
-        )
-        v_o = DefectSpecies(
-            "V_O", nsites=4,
-            charge_states=[DefectChargeState(charge=0, energy=1.0, degeneracy=1)],
-        )
         system = DefectSystem(
-            defect_species=[o_i, v_o],
+            defect_species=[self.species],
             dos=self.dos,
             volume=100,
             temperature=300,
-            element_pools={"dO": ElementPool(target=0.0, members={o_i: 2.0, "V_O": -3.0})},
+            element_pools={"Mg": ElementPool(target=0.0, members={self.species: 1.0})},
         )
         key = next(iter(system.element_pools))
         with self.assertRaises(TypeError):
             system.element_pools[key] = system.element_pools[key]
 
     def test_resolved_element_pool_members_are_read_only(self):
-        o_i = DefectSpecies(
-            "O_i", nsites=4,
-            charge_states=[DefectChargeState(charge=0, energy=1.0, degeneracy=1)],
-        )
-        v_o = DefectSpecies(
-            "V_O", nsites=4,
-            charge_states=[DefectChargeState(charge=0, energy=1.0, degeneracy=1)],
-        )
         system = DefectSystem(
-            defect_species=[o_i, v_o],
+            defect_species=[self.species],
             dos=self.dos,
             volume=100,
             temperature=300,
-            element_pools={"dO": ElementPool(target=0.0, members={o_i: 2.0, "V_O": -3.0})},
+            element_pools={"Mg": ElementPool(target=0.0, members={self.species: 1.0})},
         )
         resolved = system._resolve_element_pools()
         pool = next(iter(resolved.values()))

--- a/tests/test_pools.py
+++ b/tests/test_pools.py
@@ -18,12 +18,14 @@ class TestSitePool(unittest.TestCase):
     def test_normalises_species_to_names(self):
         pool = SitePool(n_sites=10.0, species=[_species("A"), "B"])
         self.assertEqual(pool.n_sites, 10.0)
-        self.assertEqual(pool.species, ["A", "B"])
+        self.assertEqual(pool.species, ("A", "B"))
 
-    def test_species_property_returns_a_copy(self):
+    def test_species_property_is_read_only(self):
         pool = SitePool(n_sites=1.0, species=["A"])
-        pool.species.append("X")
-        self.assertEqual(pool.species, ["A"])
+        self.assertIsInstance(pool.species, tuple)
+        with self.assertRaises(AttributeError):
+            pool.species.append("X")
+        self.assertEqual(pool.species, ("A",))
 
     def test_rejects_zero_n_sites(self):
         with self.assertRaisesRegex(ValueError, "n_sites must be finite and > 0"):
@@ -62,9 +64,10 @@ class TestElementPool(unittest.TestCase):
         self.assertEqual(pool.target, 5.0)
         self.assertEqual(pool.members, {"A": 1.0, "B": -2.0})
 
-    def test_members_property_returns_a_copy(self):
+    def test_members_property_is_read_only(self):
         pool = ElementPool(target=1.0, members={"A": 1.0})
-        pool.members["X"] = 9.0
+        with self.assertRaises(TypeError):
+            pool.members["X"] = 9.0
         self.assertEqual(pool.members, {"A": 1.0})
 
     def test_accepts_negative_target(self):


### PR DESCRIPTION
## Summary

`DefectSystem` is documented as an immutable fixed-temperature snapshot, and
`DefectSystem.result` is an unconditionally cached property whose cache-safety
rests on that immutability. Previously several container accessors returned
live-mutable internals (and the pool accessors returned defensive copies), so
the contract held only against rebinding the attribute, not against in-place
mutation of the returned container.

This unifies these container accessors on one idiom: reads return read-only
views; to obtain a mutable copy, the caller wraps explicitly (`list(...)`,
`dict(...)`).

- `DefectSystem.defect_species` and `SitePool.species` now return tuples.
- `DefectSystem.site_pools` / `element_pools` and `ElementPool.members` now
  return read-only mappings (`MappingProxyType`).
- `ResolvedElementPool.members` (an internal value object) is wrapped in a
  read-only mapping at its single construction site, closing the same
  shallow-freeze hole fixed for `DefectSystemResult` in #88.

Non-breaking: all documented use of these accessors is read-only, and the two
pool classes are v3-only and unreleased. `DefectSpecies.charge_states` (a tuple)
and the `DefectSystemResult` mappings already followed this idiom; this extends
it to the remaining container surface.

Out of scope: the `DOS.dos` / `DOS.edos` numpy arrays are still returned by
reference (a separate concern involving read-only numpy views over a shared
upstream object), left as a documented follow-up.
