### PR TITLE
Validate volume and temperature at the DefectSystem boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,14 @@
   `element_pools` and `ElementPool.members` return read-only mappings. All
   documented use is read-only, so this is non-breaking; to obtain a mutable
   copy, wrap explicitly (`list(...)`, `dict(...)`).
+- `DefectSystem` now validates `volume` and `temperature` at construction,
+  raising `ValueError` (naming the offending parameter and its value) when
+  either is not finite and > 0. `DefectSystemFactory` applies the same check to
+  `volume` at build time and to the `temperature` passed to `at()`. Previously a
+  negative volume or temperature produced silently-wrong concentrations and
+  Fermi levels, and a zero raised an opaque `ZeroDivisionError` at solve time
+  far from the construction call; these now fail immediately at the boundary,
+  matching the existing checks on the DOS, `DefectChargeState`, and `SitePool`.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,11 +225,16 @@
 - `DefectSystem` now validates `volume` and `temperature` at construction,
   raising `ValueError` (naming the offending parameter and its value) when
   either is not finite and > 0. `DefectSystemFactory` applies the same check to
-  `volume` at build time and to the `temperature` passed to `at()`. Previously a
-  negative volume or temperature produced silently-wrong concentrations and
-  Fermi levels, and a zero raised an opaque `ZeroDivisionError` at solve time
-  far from the construction call; these now fail immediately at the boundary,
-  matching the existing checks on the DOS, `DefectChargeState`, and `SitePool`.
+  `volume` at build time and to the `temperature` passed to `at()`, before any
+  temperature-dependent shift function is evaluated. Previously these bad
+  inputs failed silently or opaquely, far from the construction call. A negative
+  `temperature` inverted the Boltzmann factors, giving a converged-looking but
+  wrong Fermi level and defect concentrations; a negative `volume` left the
+  Fermi level and per-cell concentrations correct but flipped the sign of the
+  reported cm^-3 concentrations. A zero `temperature` divided by zero in the
+  solve, and a zero `volume` divided by zero when a cm^-3 concentration was
+  read. These now fail immediately at the boundary, matching the existing
+  checks on the DOS, `DefectChargeState`, and `SitePool`.
 
 ### Bug Fixes
 

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -49,10 +49,7 @@ def _require_finite_positive(value: float, name: str) -> None:
 
     Raises:
         ValueError: if ``value`` is not finite (infinite or NaN) or is not
-            greater than zero. Physical inputs such as a cell volume or a solve
-            temperature must be finite and positive: non-positive values give
-            meaningless concentrations and Fermi levels, and zero divides by
-            zero in the solve.
+            greater than zero.
     """
     if not math.isfinite(value) or value <= 0:
         raise ValueError(f"{name} must be finite and > 0; got {value}.")
@@ -1536,6 +1533,7 @@ class DefectSystemFactory:
         Raises:
             ValueError: if `temperature` is not finite and > 0.
         """
+        _require_finite_positive(temperature, "temperature")
         vbm_shift = self.vbm_shift_fn(temperature) if self.vbm_shift_fn else 0.0
         cbm_shift = self.cbm_shift_fn(temperature) if self.cbm_shift_fn else 0.0
         formation_energy_corrections = {

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -40,6 +40,24 @@ concentration), or a ``(species_name, charge_state_name)`` pair (fixes that
 single charge state)."""
 
 
+def _require_finite_positive(value: float, name: str) -> None:
+    """Reject a value that is not finite and strictly positive.
+
+    Args:
+        value: the quantity to check.
+        name: the parameter name, used in the error message.
+
+    Raises:
+        ValueError: if ``value`` is not finite (infinite or NaN) or is not
+            greater than zero. Physical inputs such as a cell volume or a solve
+            temperature must be finite and positive: non-positive values give
+            meaningless concentrations and Fermi levels, and zero divides by
+            zero in the solve.
+    """
+    if not math.isfinite(value) or value <= 0:
+        raise ValueError(f"{name} must be finite and > 0; got {value}.")
+
+
 class _VariableState(NamedTuple):
     """A non-fixed-concentration charge state within an exclusion group,
     paired with its per-site Boltzmann weight.
@@ -76,10 +94,11 @@ class DefectSystem:
     Args:
         defect_species (list[DefectSpecies]): List of ``DefectSpecies`` objects
           which are present in the ``DefectSystem``.
-        volume (float): volume of the unit cell in Angstroms cubed
+        volume (float): volume of the unit cell in Angstroms cubed. Must be
+          finite and > 0.
         dos (DOS): the ``DOS`` object associated with the unit cell
         temperature (float): temperature at which self-consistent Fermi energy
-          will be solved for.
+          will be solved for. Must be finite and > 0.
         convergence_tolerance (float, optional): Tolerance for the Fermi energy
           convergence in eV. If not specified, uses scipy's default.
         site_pools (dict[str, SitePool] | None, optional):
@@ -182,7 +201,8 @@ class DefectSystem:
           ``as_dict`` only when set. Defaults to None.
 
     Raises:
-        ValueError: if two entries in `defect_species` share a name, a pool
+        ValueError: if `volume` or `temperature` is not finite and > 0, two
+          entries in `defect_species` share a name, a pool
           references a species not in `defect_species`, a pool lists a
           species more than once, a species appears in more than one site
           pool, `formation_energy_corrections` references a `DefectChargeState`
@@ -221,6 +241,8 @@ class DefectSystem:
         occupancy_warning_threshold: float | None = 0.01,
         label: str | None = None,
     ):
+        _require_finite_positive(volume, "volume")
+        _require_finite_positive(temperature, "temperature")
         self._volume = volume
         self._dos = dos
         delta_gap = cbm_shift - vbm_shift
@@ -1412,7 +1434,8 @@ class DefectSystemFactory:
         defect_species (list[DefectSpecies]): List of ``DefectSpecies`` objects
           which are present in the ``DefectSystem``.
         dos (DOS): the ``DOS`` object associated with the unit cell.
-        volume (float): volume of the unit cell in Angstroms cubed.
+        volume (float): volume of the unit cell in Angstroms cubed. Must be
+          finite and > 0.
         convergence_tolerance (float, optional): Tolerance for the Fermi energy
           convergence in eV, passed to every `DefectSystem` built by `at()`.
         site_pools (dict[str, SitePool] | None, optional):
@@ -1443,6 +1466,11 @@ class DefectSystemFactory:
           Defaults to 0.01.
         label (str | None, optional): passed to every `DefectSystem` built by
           `at()`, unless overridden per call. Defaults to None.
+
+    Raises:
+        ValueError: if `volume` is not finite and > 0. The `temperature`
+          passed to `at()` is validated there, when the `DefectSystem` is
+          built.
     """
 
     def __init__(
@@ -1462,6 +1490,7 @@ class DefectSystemFactory:
         occupancy_warning_threshold: float | None = 0.01,
         label: str | None = None,
     ):
+        _require_finite_positive(volume, "volume")
         self.defect_species = defect_species
         self.dos = dos
         self.volume = volume
@@ -1488,7 +1517,7 @@ class DefectSystemFactory:
         Args:
             temperature (float): temperature (in K) at which to evaluate the
               shift/correction functions and solve the resulting
-              `DefectSystem`.
+              `DefectSystem`. Must be finite and > 0.
             **overrides: keyword arguments forwarded to `DefectSystem.__init__`,
               overriding any of this factory's corresponding attributes (e.g.
               `temperature` itself, or `fixed_concentrations`, a
@@ -1503,6 +1532,9 @@ class DefectSystemFactory:
 
         Returns:
             DefectSystem: a new, independent `DefectSystem` for `temperature`.
+
+        Raises:
+            ValueError: if `temperature` is not finite and > 0.
         """
         vbm_shift = self.vbm_shift_fn(temperature) if self.vbm_shift_fn else 0.0
         cbm_shift = self.cbm_shift_fn(temperature) if self.cbm_shift_fn else 0.0

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -1517,7 +1517,7 @@ class DefectSystemFactory:
               `DefectSystem`. Must be finite and > 0.
             **overrides: keyword arguments forwarded to `DefectSystem.__init__`,
               overriding any of this factory's corresponding attributes (e.g.
-              `temperature` itself, or `fixed_concentrations`, a
+              `fixed_concentrations`, a
               `dict[FixedConcentrationKey, float]` mapping a species name (or a
               ``(species_name, charge_state_name)`` pair, fixing that single
               charge state) to a fixed concentration per unit cell). Passing

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -112,6 +112,12 @@ class TestDefectSystemInputValidation(unittest.TestCase):
                 ):
                     DefectSystem(**self._kwargs(temperature=temperature))
 
+    def test_error_message_reports_the_received_value(self):
+        with self.assertRaisesRegex(
+            ValueError, r"volume must be finite and > 0; got -100"
+        ):
+            DefectSystem(**self._kwargs(volume=-100))
+
 
 class TestDefectSystem(unittest.TestCase):
     def setUp(self):
@@ -2542,6 +2548,24 @@ class TestDefectSystemFactory(unittest.TestCase):
             defect_species=[self.species], dos=self.dos, volume=100
         )
         for temperature in (0, -300, float("inf"), float("nan")):
+            with self.subTest(temperature=temperature):
+                with self.assertRaisesRegex(
+                    ValueError, r"temperature must be finite and > 0"
+                ):
+                    factory.at(temperature)
+
+    def test_at_validates_temperature_before_evaluating_shift_functions(self):
+        # A domain-restricted shift function (here a kT*ln(T)-style term) would
+        # raise its own opaque error at T <= 0 if evaluated first; `at()` must
+        # validate the temperature before any user callable sees it, so the
+        # clean boundary error is raised instead.
+        factory = DefectSystemFactory(
+            defect_species=[self.species],
+            dos=self.dos,
+            volume=100,
+            vbm_shift_fn=lambda T: math.log(T),
+        )
+        for temperature in (0, -300):
             with self.subTest(temperature=temperature):
                 with self.assertRaisesRegex(
                     ValueError, r"temperature must be finite and > 0"

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -70,6 +70,49 @@ class TestDefectSystemInit(unittest.TestCase):
         self.assertEqual(defect_system.defect_species[1].name, "O_i")
 
 
+class TestDefectSystemInputValidation(unittest.TestCase):
+    """``volume`` and ``temperature`` are physical inputs supplied at the
+    construction boundary; the constructor rejects non-finite or non-positive
+    values rather than returning silently-wrong or opaquely-failing results."""
+
+    @staticmethod
+    def _kwargs(**overrides):
+        species = Mock(spec=DefectSpecies)
+        species.name = "v_O"
+        species.charge_states = []
+        species.fixed_concentration = None
+        species.nsites = 1
+        kwargs = dict(
+            defect_species=[species],
+            volume=100.0,
+            dos=Mock(spec=DOS),
+            temperature=300.0,
+        )
+        kwargs.update(overrides)
+        return kwargs
+
+    def test_valid_volume_and_temperature_are_accepted(self):
+        system = DefectSystem(**self._kwargs())
+        self.assertEqual(system.volume, 100.0)
+        self.assertEqual(system.temperature, 300.0)
+
+    def test_rejects_non_positive_or_non_finite_volume(self):
+        for volume in (0, -100, float("inf"), float("nan")):
+            with self.subTest(volume=volume):
+                with self.assertRaisesRegex(
+                    ValueError, r"volume must be finite and > 0"
+                ):
+                    DefectSystem(**self._kwargs(volume=volume))
+
+    def test_rejects_non_positive_or_non_finite_temperature(self):
+        for temperature in (0, -300, float("inf"), float("nan")):
+            with self.subTest(temperature=temperature):
+                with self.assertRaisesRegex(
+                    ValueError, r"temperature must be finite and > 0"
+                ):
+                    DefectSystem(**self._kwargs(temperature=temperature))
+
+
 class TestDefectSystem(unittest.TestCase):
     def setUp(self):
         volume = 100
@@ -2483,6 +2526,27 @@ class TestDefectSystemFactory(unittest.TestCase):
         factory = DefectSystemFactory(defect_species=[self.species], dos=self.dos, volume=100)
         system = factory.at(300)
         self.assertEqual(system.temperature, 300)
+
+    def test_factory_rejects_non_positive_or_non_finite_volume(self):
+        for volume in (0, -100, float("inf"), float("nan")):
+            with self.subTest(volume=volume):
+                with self.assertRaisesRegex(
+                    ValueError, r"volume must be finite and > 0"
+                ):
+                    DefectSystemFactory(
+                        defect_species=[self.species], dos=self.dos, volume=volume
+                    )
+
+    def test_at_rejects_non_positive_or_non_finite_temperature(self):
+        factory = DefectSystemFactory(
+            defect_species=[self.species], dos=self.dos, volume=100
+        )
+        for temperature in (0, -300, float("inf"), float("nan")):
+            with self.subTest(temperature=temperature):
+                with self.assertRaisesRegex(
+                    ValueError, r"temperature must be finite and > 0"
+                ):
+                    factory.at(temperature)
 
     def test_at_supports_per_call_overrides(self):
         factory = DefectSystemFactory(defect_species=[self.species], dos=self.dos, volume=100)


### PR DESCRIPTION
`DefectSystem.__init__` stored `volume` and `temperature` without validation, so invalid physical inputs produced silently-wrong or opaquely-failing results:

- a negative `temperature` inverted the Boltzmann factors, giving a converged-looking but physically wrong Fermi level and defect concentrations, with no error and no warning; a negative `volume` left the Fermi level and per-cell concentrations correct but flipped the sign of the reported cm^-3 concentrations;
- a zero `temperature` divided by zero in the solve, and a zero `volume` divided by zero when a cm^-3 concentration was read — an opaque `ZeroDivisionError` far from the construction call, naming no parameter.

Every other physical input in the package already validates at its boundary (the DOS energy range and bandgap, `DefectChargeState` degeneracy, `SitePool.n_sites`), so this was a conspicuous gap, and construction from user input is exactly the boundary at which to close it.

This adds a boundary check in `DefectSystem.__init__`: `volume` and `temperature` must be finite and greater than zero, otherwise `ValueError` is raised naming the parameter and showing the received value, via a shared `_require_finite_positive` helper. `DefectSystemFactory` validates `volume` at build time and validates the `temperature` passed to `at()` at that boundary, before any temperature-dependent shift function is evaluated (a domain-restricted shift function such as a kT*ln(T) chemical-potential term would otherwise raise its own opaque error at T <= 0, defeating the clean boundary error); the `__init__` checks remain, covering direct construction and per-call overrides.

The separate `temperature` argument of the `DefectSpecies` formation-energy methods (`get_transition_level_and_energy`, `effective_formation_energy`, and related), which legitimately defaults to zero for the analytic T=0 formation-energy envelope, is a different parameter for a different calculation and is left unchanged.
