### PR TITLE
Fix transition-level walk crashing on out-of-range fixed charge states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,14 @@
   each species' occupancy is now divided by the sites available to it (its own
   `nsites`, or the shared `site_pools` size for a pooled species), so every
   reported occupancy is at most 100%.
+- `DefectSpecies.tl_profile` and `DefectSystem.get_transition_levels` no longer
+  raise `KeyError` when a species has a fixed-concentration charge state whose
+  charge lies outside the range of its variable charge states. The
+  transition-level walk now ranges only over the variable
+  (formation-energy-bearing) charge states, so a fixed charge state is ignored
+  rather than treated as a transition-level endpoint. Calling
+  `DefectSpecies.get_transition_level_and_energy` directly with a non-variable
+  charge now raises a descriptive `ValueError` rather than a bare `KeyError`.
 
 ## V2.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,14 +246,12 @@
   each species' occupancy is now divided by the sites available to it (its own
   `nsites`, or the shared `site_pools` size for a pooled species), so every
   reported occupancy is at most 100%.
-- `DefectSpecies.tl_profile` and `DefectSystem.get_transition_levels` no longer
-  raise `KeyError` when a species has a fixed-concentration charge state whose
-  charge lies outside the range of its variable charge states. The
-  transition-level walk now ranges only over the variable
-  (formation-energy-bearing) charge states, so a fixed charge state is ignored
-  rather than treated as a transition-level endpoint. Calling
-  `DefectSpecies.get_transition_level_and_energy` directly with a non-variable
-  charge now raises a descriptive `ValueError` rather than a bare `KeyError`.
+- `DefectSpecies.tl_profile` and `DefectSystem.get_transition_levels` now ignore
+  a species' fixed-concentration charge states, which carry no formation energy
+  and so define no transition level; previously such a state could raise
+  `KeyError`. Calling `DefectSpecies.get_transition_level_and_energy` directly
+  with a non-variable charge now raises a descriptive `ValueError` rather than a
+  bare `KeyError`.
 
 ## V2.2.2
 

--- a/py_sc_fermi/defect_species.py
+++ b/py_sc_fermi/defect_species.py
@@ -380,6 +380,10 @@ class DefectSpecies:
         """get transition level profile for this ``DefectSpecies`` between a
         minimum and maximum Fermi energy.
 
+        Only variable-concentration charge states define transition levels;
+        fixed-concentration charge states carry no formation energy and are
+        excluded from the profile.
+
         Args:
             efermi_min (float): minimum Fermi energy
             efermi_max (float): maximum Fermi energy
@@ -457,7 +461,7 @@ class DefectSpecies:
         for q in (q1, q2):
             if q not in form_eners:
                 raise ValueError(
-                    f"DefectSpecies '{self.name}': charge {q:+d} has no "
+                    f"DefectSpecies '{self.name}': charge {q:+} has no "
                     "formation energy; transition levels are defined only "
                     "between variable-concentration charge states."
                 )

--- a/py_sc_fermi/defect_species.py
+++ b/py_sc_fermi/defect_species.py
@@ -405,8 +405,8 @@ class DefectSpecies:
             )
         q1 = min(form_eners, key=form_eners.__getitem__)
         points = [(efermi_min, form_eners[q1])]
-        while q1 != min(self.charges):
-            qlist = [q for q in self.charges if q < q1]
+        while q1 != min(form_eners):
+            qlist = [q for q in form_eners if q < q1]
             nextp, nextq = min(
                 (
                     (
@@ -446,9 +446,21 @@ class DefectSpecies:
             tuple[float, float]: Fermi energy and formation energy of the
             transition level between ``DefectChargeState`` objects with charges
             q1 and q2.
+
+        Raises:
+            ValueError: if either ``q1`` or ``q2`` is not a
+                variable-concentration charge of this species, and so has no
+                formation energy from which to define a transition level.
         """
 
         form_eners = self.get_formation_energies(0, temperature=temperature)
+        for q in (q1, q2):
+            if q not in form_eners:
+                raise ValueError(
+                    f"DefectSpecies '{self.name}': charge {q:+d} has no "
+                    "formation energy; transition levels are defined only "
+                    "between variable-concentration charge states."
+                )
         trans_level = (form_eners[q2] - form_eners[q1]) / (q1 - q2)
         energy = q1 * trans_level + form_eners[q1]
         return (trans_level, energy)

--- a/tests/test_defect_species.py
+++ b/tests/test_defect_species.py
@@ -542,9 +542,30 @@ class TestDefectSpecies(unittest.TestCase):
             with_fixed.tl_profile(0, 5), without_fixed.tl_profile(0, 5)
         )
 
+    def test_tl_profile_ignores_fixed_charge_state_between_variable_charges(self):
+        # The canonical case: a fixed charge state whose charge sits between the
+        # variable charges. It is within the charge range but still non-variable,
+        # so a walk that merely clamped to the variable charge range would wrongly
+        # include it. The profile must match the species without it (previously a
+        # KeyError).
+        variable_states = [
+            DefectChargeState(charge=0, energy=2, degeneracy=1),
+            DefectChargeState(charge=2, energy=-1, degeneracy=1),
+        ]
+        without_fixed = DefectSpecies("foo", 1, variable_states)
+        with_fixed = DefectSpecies(
+            "foo",
+            1,
+            [*variable_states, DefectChargeState(charge=1, fixed_concentration=1e-3)],
+        )
+        np.testing.assert_array_almost_equal(
+            with_fixed.tl_profile(0, 5), without_fixed.tl_profile(0, 5)
+        )
+
     def test_tl_profile_ignores_fixed_charge_state_above_variable_range(self):
-        # The mirror case: a fixed charge state above the variable range must
-        # likewise leave the variable-only profile unchanged.
+        # A fixed charge above the variable range is never reached by the
+        # descending walk, so this case did not crash pre-fix; the test guards
+        # against the fix perturbing that already-correct path.
         variable_states = [
             DefectChargeState(charge=0, energy=2, degeneracy=1),
             DefectChargeState(charge=2, energy=-1, degeneracy=1),
@@ -576,8 +597,9 @@ class TestDefectSpecies(unittest.TestCase):
         self.assertIn("V_O", str(cm.exception))
 
     def test_tl_profile_with_single_variable_charge_state(self):
-        # A single variable charge state admits no transitions; the profile is
-        # the flat formation-energy line between the two Fermi-energy bounds.
+        # A single variable charge state admits no transitions, so the profile
+        # is just that state's formation-energy line at the two bounds (flat
+        # here because the charge is 0).
         defect = DefectSpecies(
             "foo", 1, [DefectChargeState(charge=0, energy=2, degeneracy=1)]
         )

--- a/tests/test_defect_species.py
+++ b/tests/test_defect_species.py
@@ -523,6 +523,80 @@ class TestDefectSpecies(unittest.TestCase):
         # the q=+1 endpoint reflects the lower-energy (0.5 eV) state
         self.assertAlmostEqual(profile_a[0][1], 0.5)
 
+    def test_tl_profile_ignores_fixed_charge_state_below_variable_range(self):
+        # A fixed-concentration charge state whose charge lies below the
+        # variable charges has no formation energy, so it cannot be a
+        # transition-level endpoint. The walk must ignore it and return the
+        # same profile as the species without it (previously a KeyError).
+        variable_states = [
+            DefectChargeState(charge=0, energy=2, degeneracy=1),
+            DefectChargeState(charge=2, energy=-1, degeneracy=1),
+        ]
+        without_fixed = DefectSpecies("foo", 1, variable_states)
+        with_fixed = DefectSpecies(
+            "foo",
+            1,
+            [*variable_states, DefectChargeState(charge=-1, fixed_concentration=1e-3)],
+        )
+        np.testing.assert_array_almost_equal(
+            with_fixed.tl_profile(0, 5), without_fixed.tl_profile(0, 5)
+        )
+
+    def test_tl_profile_ignores_fixed_charge_state_above_variable_range(self):
+        # The mirror case: a fixed charge state above the variable range must
+        # likewise leave the variable-only profile unchanged.
+        variable_states = [
+            DefectChargeState(charge=0, energy=2, degeneracy=1),
+            DefectChargeState(charge=2, energy=-1, degeneracy=1),
+        ]
+        without_fixed = DefectSpecies("foo", 1, variable_states)
+        with_fixed = DefectSpecies(
+            "foo",
+            1,
+            [*variable_states, DefectChargeState(charge=3, fixed_concentration=1e-3)],
+        )
+        np.testing.assert_array_almost_equal(
+            with_fixed.tl_profile(0, 5), without_fixed.tl_profile(0, 5)
+        )
+
+    def test_tl_profile_raises_with_no_variable_charge_states(self):
+        # An all-fixed species has no formation-energy line anywhere, so a
+        # transition-level profile is undefined, matching
+        # min_energy_charge_state and effective_formation_energy.
+        defect = DefectSpecies(
+            "V_O",
+            1,
+            [
+                DefectChargeState(charge=0, fixed_concentration=0.5),
+                DefectChargeState(charge=1, fixed_concentration=0.3),
+            ],
+        )
+        with self.assertRaises(ValueError) as cm:
+            defect.tl_profile(0, 5)
+        self.assertIn("V_O", str(cm.exception))
+
+    def test_tl_profile_with_single_variable_charge_state(self):
+        # A single variable charge state admits no transitions; the profile is
+        # the flat formation-energy line between the two Fermi-energy bounds.
+        defect = DefectSpecies(
+            "foo", 1, [DefectChargeState(charge=0, energy=2, degeneracy=1)]
+        )
+        np.testing.assert_array_almost_equal(defect.tl_profile(0, 5), [[0, 2], [5, 2]])
+
+    def test_get_transition_level_and_energy_raises_for_non_variable_charge(self):
+        # Called directly with a fixed (non-variable) charge, a clear ValueError
+        # is raised rather than a bare KeyError.
+        defect = DefectSpecies(
+            "foo",
+            1,
+            [
+                DefectChargeState(charge=0, energy=0.0, degeneracy=1),
+                DefectChargeState(charge=-1, fixed_concentration=1e-3),
+            ],
+        )
+        with self.assertRaisesRegex(ValueError, "no formation energy"):
+            defect.get_transition_level_and_energy(0, -1)
+
     def test__repr__(self):
         self.defect_species._charge_states = [
             DefectChargeState(2, energy=-1, degeneracy=1)

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -353,6 +353,34 @@ class TestDefectSystem(unittest.TestCase):
             {"v_O": [[1, 1], [2, 2]], "O_i": [[1, 1], [2, 2]]},
         )
 
+    def test_get_transition_levels_ignores_fixed_charge_state_below_range(self):
+        # A species carrying a fixed-concentration charge state below its
+        # variable charges must not break the system-level transition-level
+        # walk (previously a KeyError); the fixed state is simply ignored.
+        variable_states = [
+            DefectChargeState(charge=0, energy=2.0, degeneracy=1),
+            DefectChargeState(charge=2, energy=-1.0, degeneracy=1),
+        ]
+        dos = semiconducting_dos()
+
+        def system_for(charge_states):
+            return DefectSystem(
+                defect_species=[DefectSpecies("V_O", 1, charge_states)],
+                volume=100,
+                dos=dos,
+                temperature=300,
+                convergence_tolerance=1e-6,
+            )
+
+        with_fixed = system_for(
+            [*variable_states, DefectChargeState(charge=-1, fixed_concentration=1e-3)]
+        )
+        without_fixed = system_for(variable_states)
+        np.testing.assert_array_almost_equal(
+            with_fixed.get_transition_levels()["V_O"],
+            without_fixed.get_transition_levels()["V_O"],
+        )
+
     def test_named_metastable_states_are_reported_separately(self):
         # Named metastable states use their names as keys.
         cs_a = DefectChargeState(charge=0, fixed_concentration=0.6, name="V_O_tet")


### PR DESCRIPTION
`DefectSpecies.tl_profile` (and `DefectSystem.get_transition_levels`, which
calls it) raised `KeyError` when a species had a fixed-concentration charge
state whose charge lay outside the range of its variable charge states. The
transition-level walk bounded its loop and built its candidate list from
`self.charges` (all charge states) but read energies from
`get_formation_energies` (variable charge states only), so stepping down onto
a fixed-only charge looked up an energy that was not present. A fixed charge
above the variable range was unaffected.

The walk now ranges over the variable (formation-energy-bearing) charge
states, so a fixed charge state is never treated as a transition-level
endpoint. `get_transition_level_and_energy` now raises a descriptive
`ValueError`, rather than a bare `KeyError`, when called directly with a
non-variable charge.

Degenerate cases are unchanged: an all-fixed species still raises a clear
`ValueError` (consistent with `min_energy_charge_state` and
`effective_formation_energy`), and a single variable charge state still
returns a flat profile.
