### PR TITLE
Expose the high-occupancy verdict as data on DefectSystemResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,15 @@
   high occupancy flags a regime in which un-modelled defect-defect interactions
   may make the results non-physical. The threshold is a reporting preference
   and is not serialised.
+- Added `DefectSystemResult.high_occupancy_species`, a read-only mapping of the
+  species whose solved site occupancy exceeds the system's
+  `occupancy_warning_threshold` to that occupancy fraction, ordered worst first
+  (empty when none exceed it, or when the threshold is `None`). This is the same
+  verdict the `DiluteLimitWarning` reports, exposed as inspectable data on the
+  cached `result`, so it survives warning suppression: a solve run under
+  `warnings.catch_warnings()` / `simplefilter("ignore")` (e.g. a batch
+  temperature sweep) still records the verdict, where relying on the fire-once
+  warning alone would lose it.
 - Added a `PyScFermiWarning` base class so all py-sc-fermi warnings can be
   filtered as a group. `DiluteLimitWarning` now subclasses it, and
   `DefectChargeState.from_dict` emits the new `UnrecognisedKeyWarning` for

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -1109,30 +1109,30 @@ class DefectSystem:
         self._warn_if_high_occupancy(e_fermi)
         return e_fermi, residual
 
-    def _warn_if_high_occupancy(self, e_fermi: float) -> None:
-        """Emit a ``DiluteLimitWarning`` if any species' solved site occupancy
-        exceeds ``occupancy_warning_threshold``.
+    def _high_occupancy_offenders(self, e_fermi: float) -> list[tuple[str, float]]:
+        """Species whose solved site occupancy exceeds
+        ``occupancy_warning_threshold``, ordered worst (highest occupancy)
+        first.
 
-        Does nothing when the threshold is ``None`` or when this system has
-        already warned. Otherwise computes the per-species occupancy fractions
-        at the converged ``e_fermi`` and, if any species is above the threshold,
-        emits one warning naming every offending species and its occupancy,
-        worst first. The warning fires at most once per ``DefectSystem``: the
-        occupancy verdict is deterministic for an immutable snapshot, so a user
-        inspecting one solved system through several routes (a direct
-        ``get_sc_fermi``, or the deeper ``result``, ``site_percentages`` or
-        ``element_chemical_potential_shifts``) sees a single warning, attributed
-        to their own call rather than to an internal solve method.
+        Returns an empty list when the threshold is ``None`` (the dilute-limit
+        check is disabled) or no species exceeds it. Shared by the
+        ``DiluteLimitWarning`` and ``DefectSystemResult.high_occupancy_species``
+        so the fire-once warning and the always-inspectable data report the same
+        verdict from a single solved ``e_fermi``.
 
         Args:
-            e_fermi (float): the self-consistent Fermi energy from
+            e_fermi (float): a self-consistent Fermi energy, as returned by
               ``get_sc_fermi``.
+
+        Returns:
+            list[tuple[str, float]]: ``(species name, occupancy fraction)``
+            pairs for the species above the threshold, highest occupancy first.
         """
         threshold = self.occupancy_warning_threshold
-        if self._occupancy_warning_emitted or threshold is None:
-            return
+        if threshold is None:
+            return []
         fractions = self._site_occupancy_fractions(e_fermi)
-        offenders = sorted(
+        return sorted(
             (
                 (name, fraction)
                 for name, fraction in fractions.items()
@@ -1141,6 +1141,33 @@ class DefectSystem:
             key=lambda item: item[1],
             reverse=True,
         )
+
+    def _warn_if_high_occupancy(self, e_fermi: float) -> None:
+        """Emit a ``DiluteLimitWarning`` if any species' solved site occupancy
+        exceeds ``occupancy_warning_threshold``.
+
+        Does nothing when the threshold is ``None`` or when this system has
+        already warned. Otherwise, if any species is above the threshold
+        (``_high_occupancy_offenders``), emits one warning naming every
+        offending species and its occupancy, worst first. The warning fires at
+        most once per ``DefectSystem``: the occupancy verdict is deterministic
+        for an immutable snapshot, so a user inspecting one solved system
+        through several routes (a direct ``get_sc_fermi``, or the deeper
+        ``result``, ``site_percentages`` or
+        ``element_chemical_potential_shifts``) sees a single warning, attributed
+        to their own call rather than to an internal solve method.
+
+        The same verdict is always available, filter-independent, as
+        ``result.high_occupancy_species``; this warning is a convenience signal
+        on top of it.
+
+        Args:
+            e_fermi (float): the self-consistent Fermi energy from
+              ``get_sc_fermi``.
+        """
+        if self._occupancy_warning_emitted:
+            return
+        offenders = self._high_occupancy_offenders(e_fermi)
         if not offenders:
             return
         warnings.warn(

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -1160,8 +1160,7 @@ class DefectSystem:
         to their own call rather than to an internal solve method.
 
         The same verdict is always available, filter-independent, as
-        ``result.high_occupancy_species``; this warning is a convenience signal
-        on top of it.
+        ``result.high_occupancy_species``.
 
         Args:
             e_fermi (float): the self-consistent Fermi energy from

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -1048,6 +1048,7 @@ class DefectSystem:
             e_fermi, _ = self.get_sc_fermi()
             p0, n0 = self.dos.carrier_concentrations(e_fermi, self.temperature)
             per_cell = self._per_charge_state_concs(e_fermi)
+            offenders = self._high_occupancy_offenders(e_fermi)
             self._result = DefectSystemResult(
                 temperature=float(self.temperature),
                 fermi_energy=float(e_fermi),
@@ -1061,6 +1062,7 @@ class DefectSystem:
                         for species, states in per_cell.items()
                     }
                 ),
+                high_occupancy_species=MappingProxyType(dict(offenders)),
             )
         return self._result
 

--- a/py_sc_fermi/defect_system_result.py
+++ b/py_sc_fermi/defect_system_result.py
@@ -27,6 +27,14 @@ class DefectSystemResult:
         n0_per_cell: electron concentration per unit cell.
         charge_state_concentrations_per_cell: per-unit-cell concentrations keyed
             by species name then charge-state name.
+        high_occupancy_species: species whose solved site occupancy exceeds the
+            originating system's ``occupancy_warning_threshold``, mapped to that
+            occupancy fraction (0.0-1.0) and ordered worst (highest occupancy)
+            first. Empty when no species exceeds the threshold, or when the
+            threshold is ``None`` (the dilute-limit check is disabled). This is
+            the same verdict the ``DiluteLimitWarning`` reports, exposed as data
+            so it is always inspectable regardless of the warnings filter -- a
+            solve run under suppressed warnings still records it here.
     """
 
     temperature: float
@@ -36,6 +44,7 @@ class DefectSystemResult:
     p0_per_cell: float
     n0_per_cell: float
     charge_state_concentrations_per_cell: Mapping[str, Mapping[str, float]]
+    high_occupancy_species: Mapping[str, float]
 
     # @dataclass synthesises __hash__ onto this class; setting __hash__ = None
     # keeps instances unhashable, as they hold dict/mapping fields that a

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -3641,27 +3641,31 @@ class TestDiluteLimitWarning(unittest.TestCase):
         self.assertEqual(calls["n"], 1)
 
     def test_result_high_occupancy_species_lists_offenders_worst_first(self):
-        # Two neutral (e_fermi-independent) states at distinct occupancies; the
-        # lower-occupancy species is listed FIRST at construction, so the test
-        # fails unless high_occupancy_species is re-ordered worst-first. The
-        # fractions are the same solved values site_percentages reports.
-        low = DefectSpecies(
-            "low_occ",
-            nsites=1,
-            charge_states=[DefectChargeState(charge=0, energy=0.1, degeneracy=1)],
+        # Three neutral (e_fermi-independent) states at distinct occupancies,
+        # declared in non-monotonic order (mid, high, low): the verdict must be
+        # value-sorted worst-first (high, mid, low). A plain insertion-order
+        # pass-through or a mere reversal would each order it differently, so
+        # this pins the sort rather than an accidental ordering. The fractions
+        # are the same solved values site_percentages reports.
+        def neutral(name, energy):
+            return DefectSpecies(
+                name,
+                nsites=1,
+                charge_states=[
+                    DefectChargeState(charge=0, energy=energy, degeneracy=1)
+                ],
+            )
+
+        system = self._make_system(
+            [neutral("mid_occ", 0.05), neutral("high_occ", 0.0), neutral("low_occ", 0.1)],
+            occupancy_warning_threshold=0.01,
         )
-        high = DefectSpecies(
-            "high_occ",
-            nsites=1,
-            charge_states=[DefectChargeState(charge=0, energy=0.0, degeneracy=1)],
-        )
-        system = self._make_system([low, high], occupancy_warning_threshold=0.01)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             hos = system.result.high_occupancy_species
             percentages = system.site_percentages()
-        self.assertEqual(list(hos), ["high_occ", "low_occ"])
-        for name in ("high_occ", "low_occ"):
+        self.assertEqual(list(hos), ["high_occ", "mid_occ", "low_occ"])
+        for name in ("high_occ", "mid_occ", "low_occ"):
             self.assertAlmostEqual(hos[name], percentages[name] / 100, places=10)
 
     def test_result_high_occupancy_species_empty_when_all_dilute(self):
@@ -3683,15 +3687,19 @@ class TestDiluteLimitWarning(unittest.TestCase):
 
     def test_result_high_occupancy_species_is_read_only(self):
         # result caches one object; a mutable mapping would let a caller corrupt
-        # the cache in place. Consistent with charge_state_concentrations_per_cell.
-        system = self._make_system(
-            [self._saturating_species("S")], occupancy_warning_threshold=0.01
+        # the cache in place. A mappingproxy rejects assignment even when empty,
+        # so a dilute species exercises the read-only contract without any
+        # warning-suppression machinery. Consistent with
+        # charge_state_concentrations_per_cell.
+        dilute = DefectSpecies(
+            "D",
+            nsites=1,
+            charge_states=[DefectChargeState(charge=0, energy=1.0, degeneracy=1)],
         )
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            hos = system.result.high_occupancy_species
+        system = self._make_system([dilute])  # empty verdict, emits no warning
+        hos = system.result.high_occupancy_species
         with self.assertRaises(TypeError):
-            hos["S"] = 0.0
+            hos["D"] = 0.0
 
     def test_high_occupancy_species_survives_warning_suppression(self):
         # The regression this change fixes: a batch sweep under

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -3640,6 +3640,72 @@ class TestDiluteLimitWarning(unittest.TestCase):
         _ = system.element_chemical_potential_shifts()
         self.assertEqual(calls["n"], 1)
 
+    def test_result_high_occupancy_species_lists_offenders_worst_first(self):
+        # Two neutral (e_fermi-independent) states at distinct occupancies; the
+        # lower-occupancy species is listed FIRST at construction, so the test
+        # fails unless high_occupancy_species is re-ordered worst-first. The
+        # fractions are the same solved values site_percentages reports.
+        low = DefectSpecies(
+            "low_occ",
+            nsites=1,
+            charge_states=[DefectChargeState(charge=0, energy=0.1, degeneracy=1)],
+        )
+        high = DefectSpecies(
+            "high_occ",
+            nsites=1,
+            charge_states=[DefectChargeState(charge=0, energy=0.0, degeneracy=1)],
+        )
+        system = self._make_system([low, high], occupancy_warning_threshold=0.01)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            hos = system.result.high_occupancy_species
+            percentages = system.site_percentages()
+        self.assertEqual(list(hos), ["high_occ", "low_occ"])
+        for name in ("high_occ", "low_occ"):
+            self.assertAlmostEqual(hos[name], percentages[name] / 100, places=10)
+
+    def test_result_high_occupancy_species_empty_when_all_dilute(self):
+        species = DefectSpecies(
+            "D",
+            nsites=1,
+            charge_states=[DefectChargeState(charge=0, energy=1.0, degeneracy=1)],
+        )
+        system = self._make_system([species])  # default threshold 0.01
+        self.assertEqual(dict(system.result.high_occupancy_species), {})
+
+    def test_result_high_occupancy_species_empty_when_threshold_none(self):
+        # The saturating species would be an offender at any set threshold, but
+        # a None threshold disables the check, so the verdict is empty.
+        system = self._make_system(
+            [self._saturating_species("S")], occupancy_warning_threshold=None
+        )
+        self.assertEqual(dict(system.result.high_occupancy_species), {})
+
+    def test_result_high_occupancy_species_is_read_only(self):
+        # result caches one object; a mutable mapping would let a caller corrupt
+        # the cache in place. Consistent with charge_state_concentrations_per_cell.
+        system = self._make_system(
+            [self._saturating_species("S")], occupancy_warning_threshold=0.01
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            hos = system.result.high_occupancy_species
+        with self.assertRaises(TypeError):
+            hos["S"] = 0.0
+
+    def test_high_occupancy_species_survives_warning_suppression(self):
+        # The regression this change fixes: a batch sweep under
+        # simplefilter("ignore") filters the DiluteLimitWarning away and trips
+        # the once-per-instance latch, so a later look at the warning alone
+        # finds nothing. The data path on the result carries the verdict
+        # regardless of the warnings filter.
+        system = self._make_system([self._saturating_species("S")])
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = system.result
+        self.assertIn("S", result.high_occupancy_species)
+        self.assertGreater(result.high_occupancy_species["S"], 0.01)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_defect_system_result.py
+++ b/tests/test_defect_system_result.py
@@ -90,7 +90,8 @@ class DefectSystemResultSerialisationTestCase(unittest.TestCase):
             p0_per_cell=2.0,
             n0_per_cell=4.0,
             charge_state_concentrations_per_cell={"V_O": {"q+2": 1.0, "q0": 3.0}},
-            high_occupancy_species={},
+            # non-empty so the as_dict key-set assertion is a real exclusion guard
+            high_occupancy_species={"V_O": 0.9},
         )
 
     def test_as_dict_shape_keys_and_units(self):

--- a/tests/test_defect_system_result.py
+++ b/tests/test_defect_system_result.py
@@ -17,6 +17,22 @@ class DefectSystemResultViewsTestCase(unittest.TestCase):
                 "V_O": {"q+2": 1.0, "q0": 3.0},
                 "Ti_i": {"q+4": 5.0},
             },
+            high_occupancy_species={},
+        )
+
+    def test_high_occupancy_species_stored_verbatim(self):
+        r = DefectSystemResult(
+            temperature=300.0,
+            fermi_energy=0.5,
+            volume=100.0,
+            label=None,
+            p0_per_cell=2.0,
+            n0_per_cell=4.0,
+            charge_state_concentrations_per_cell={"V_O": {"q+2": 1.0}},
+            high_occupancy_species={"hi": 0.9, "lo": 0.2},
+        )
+        self.assertEqual(
+            list(r.high_occupancy_species.items()), [("hi", 0.9), ("lo", 0.2)]
         )
 
     def test_per_cell_fields_stored_verbatim(self):
@@ -74,6 +90,7 @@ class DefectSystemResultSerialisationTestCase(unittest.TestCase):
             p0_per_cell=2.0,
             n0_per_cell=4.0,
             charge_state_concentrations_per_cell={"V_O": {"q+2": 1.0, "q0": 3.0}},
+            high_occupancy_species={},
         )
 
     def test_as_dict_shape_keys_and_units(self):
@@ -128,6 +145,7 @@ class DefectSystemResultStrTestCase(unittest.TestCase):
             p0_per_cell=2.0,
             n0_per_cell=4.0,
             charge_state_concentrations_per_cell={"V_O": {"q+2": 3.0, "q0": 1.0}},
+            high_occupancy_species={},
         )
 
     def test_str_reports_solution_only(self):
@@ -150,6 +168,7 @@ class DefectSystemResultStrTestCase(unittest.TestCase):
             temperature=300.0, fermi_energy=0.5, volume=100.0, label=None,
             p0_per_cell=2.0, n0_per_cell=4.0,
             charge_state_concentrations_per_cell={"X": {"q0": 0.0}},
+            high_occupancy_species={},
         )
         text = str(r)
         self.assertIn("0.00%", text)


### PR DESCRIPTION
## Summary

`DefectSystem`'s `DiluteLimitWarning` names the species whose solved site
occupancy exceeds `occupancy_warning_threshold`, flagging a regime where the
dilute (lattice-gas) model may be non-physical. The warning fires at most once
per instance, and its once-guard is armed whenever `warnings.warn` is called,
including when a filter discards it (a batch temperature sweep under
`warnings.catch_warnings()` / `simplefilter("ignore")`, or pytest's
`filterwarnings`). A first solve under suppression therefore lost the verdict
permanently, since the threshold is construction-only and never re-arms.

This exposes the same verdict as inspectable data, so it no longer depends on
the warnings filter.

## What lands

- `DefectSystemResult.high_occupancy_species`: a read-only mapping (a
  `MappingProxyType`, matching the type's immutability contract) of each
  offending species to its solved site-occupancy fraction, ordered worst
  (highest occupancy) first. It is empty when no species exceeds the threshold,
  or when the threshold is `None` (the check is disabled).
- The `result` builder computes it once from the solved Fermi level, reusing the
  same `_high_occupancy_offenders` helper the warning uses, so the warning and
  the data report one verdict from a single solve.

The `DiluteLimitWarning` and its once-per-instance latch are unchanged; this
change is purely additive.

## Notes for review

- **Offenders, not all species' fractions.** `high_occupancy_species` holds only
  the species above the threshold, matching what the warning reports. Exposing
  every species' fraction (threshold-independent, usable even when the threshold
  is `None`) would be more general but a poorer match to the warning and a
  larger payload, so it was declined.
- **Deliberately not serialised.** The verdict derives from
  `occupancy_warning_threshold`, a reporting preference that `as_dict()` does not
  round-trip, so it is kept out of `as_dict()` and `str(result)` for the same
  reason.
