### PR TITLE
Correct stale docstrings, remove dead code, and pin convergence_tolerance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@
 
 ### Improvements
 
+- Corrected stale docstrings to match the current code (`DOS.from_vasprun`'s
+  `nelect` handling, `DOS.as_dict`'s `spin_pol` note, and the sign in
+  `DefectSystem.q_tot`'s description of the returned net charge), and removed the
+  unused `DefectSpecies.site_weights` method.
 - `DefectChargeState` has a `name` attribute, used as the key in
   `DefectSystem.result.charge_state_concentrations`. It defaults to the charge
   string (`"q+2"`); explicit names are required for metastable states sharing a

--- a/py_sc_fermi/defect_charge_state.py
+++ b/py_sc_fermi/defect_charge_state.py
@@ -17,10 +17,13 @@ class DefectChargeState:
 
     Args:
          charge (int): charge of this ``DefectChargeState``
-         degeneracy (float): degeneracy of this charge state
-         energy (float): formation energy at E[Fermi] = 0
-         fixed_concentration (float): fixed concentration per unit cell.
-           Must be finite and non-negative.
+         degeneracy (float, optional): degeneracy of this charge state.
+           Defaults to 1.
+         energy (float | None, optional): formation energy at E[Fermi] = 0.
+           Defaults to None; either ``energy`` or ``fixed_concentration`` must
+           be given.
+         fixed_concentration (float | None, optional): fixed concentration per
+           unit cell. Must be finite and non-negative. Defaults to None.
          name (str | None): identifying label for this charge state, used as
            the key in ``DefectSystem.result.charge_state_concentrations``
            (keyed by species name then charge-state name). Defaults to the

--- a/py_sc_fermi/defect_species.py
+++ b/py_sc_fermi/defect_species.py
@@ -115,7 +115,7 @@ class DefectSpecies:
     def charge_states(
         self,
     ) -> tuple[DefectChargeState, ...]:
-        """
+        """The charge states that comprise this ``DefectSpecies``.
 
         Returns:
             tuple[DefectChargeState, ...]: the ``DefectChargeState`` objects
@@ -153,23 +153,6 @@ class DefectSpecies:
             list[int]: list of charge states of this ``DefectSpecies``
         """
         return [cs.charge for cs in self._charge_states]
-    
-    def site_weights(
-        self, e_fermi: float, temperature: float
-    ) -> list[tuple[float, DefectChargeState, float]]:
-        """
-        For *variable* charge‐states only, return
-            (nsites, DefectChargeState, weight)
-        where
-            weight = g * exp( - E_f(e_fermi) / (k_B * T) )
-        """
-        weights: list[tuple[float, DefectChargeState, float]] = []
-        for cs in self.variable_conc_charge_states():
-            Ef = cs.get_formation_energy(e_fermi)
-            w  = cs.degeneracy * np.exp(-Ef / (kboltz * temperature))
-            weights.append((self.nsites, cs, w))
-        return weights
-
 
     @property
     def fixed_concentration(self) -> float | None:
@@ -484,7 +467,7 @@ class DefectSpecies:
             If this ``DefectSpecies`` has a set fixed concentration, then this
             will be returned.
         """
-        # Honor a forced total immediately
+        # Honour a forced total immediately
         if self.fixed_concentration is not None:
             return self.fixed_concentration
 
@@ -527,7 +510,7 @@ class DefectSpecies:
 
         - For states with `fixed_concentration` set: that value is used directly.
         - For variable states: c_cell = c_site * nsites, where
-            c_site = exp(–E_f/EkBT)·degeneracy per site.
+            c_site = exp(-E_f / (kB * T)) * degeneracy per site.
 
         If the species itself has `fixed_concentration` set, all variable-state
         concentrations are rescaled as a group so that

--- a/py_sc_fermi/defect_system.py
+++ b/py_sc_fermi/defect_system.py
@@ -1228,7 +1228,18 @@ class DefectSystem:
             f"level. {caveat}"
         )
 
-    def total_defect_charge_contributions(self, e_fermi: float) -> tuple[float,float]:
+    def total_defect_charge_contributions(self, e_fermi: float) -> tuple[float, float]:
+        """Sum the defects' charge contributions at a given Fermi energy.
+
+        Args:
+            e_fermi (float): Fermi energy.
+
+        Returns:
+            tuple[float, float]: the total positive defect charge and the total
+            absolute negative defect charge per unit cell at ``e_fermi``, each a
+            sum of ``concentration * |charge|`` over the charge states of that
+            sign.
+        """
         lhs = rhs = 0.0
         for cs, conc in self._global_defect_concs(e_fermi).items():
             if cs.charge > 0:
@@ -1240,8 +1251,8 @@ class DefectSystem:
     def q_tot(self, e_fermi: float) -> float:
         """for a given Fermi energy, calculate the net charge density of the
         ``DefectSystem`` as the difference between charge contributions from all
-        positive species (including holes) and all negative species (including
-        electrons).
+        negative species (including electrons) and all positive species
+        (including holes).
 
         Args:
             e_fermi (float): Fermi energy
@@ -1257,9 +1268,10 @@ class DefectSystem:
         return diff
 
     def get_transition_levels(self) -> dict[str, list[list]]:
-        """Return transition_levels transition levels profiles of all ``DefectSpecies``
-        all defects as dictionary of ``{DefectSpecies.name : [e_fermi, e_formation]}``
-        over the whole density of states energy range.
+        """Return the transition-level profile of every ``DefectSpecies`` in the
+        system, as a dictionary of
+        ``{name: [e_fermi_values, e_formation_values]}`` over the full
+        density-of-states energy range.
 
         Returns:
             dict[str, list[list]]: Dictionary giving per-defect transition-level

--- a/py_sc_fermi/dos.py
+++ b/py_sc_fermi/dos.py
@@ -125,16 +125,25 @@ class DOS:
         nelect: int | None = None,
         bandgap: float | None = None,
     ) -> DOS:
-        """Generate DOS object from a VASP vasprun.xml
-        file. As this is parsed using pymatgen, the number of electrons is not
-        contained in the vasprun data and must be passed in. On the other hand,
-        If the bandgap is not passed in, it can be read from the vasprun file.
+        """Generate a ``DOS`` object from a VASP ``vasprun.xml`` file, parsed
+        with pymatgen. If ``nelect`` is not given it is read from the vasprun's
+        ``NELECT`` parameter; if ``bandgap`` is not given it is read from the
+        vasprun's eigenvalue band properties.
 
         Args:
-            path_to_vasprun (str): path to vasprun file
-            nelect (int): number of electrons in vasp calculation associated with
-              the vasprun
-            bandgap (float | None, optional): bandgap. Defaults to None.
+            path_to_vasprun (str): path to the vasprun file.
+            nelect (int | None, optional): number of electrons in the VASP
+              calculation. Defaults to None (read from the vasprun's ``NELECT``
+              parameter).
+            bandgap (float | None, optional): band gap. Defaults to None (read
+              from the vasprun).
+
+        Returns:
+            DOS: a ``DOS`` object built from the vasprun data.
+
+        Raises:
+            TypeError: if pymatgen's ``eigenvalue_band_properties`` does not have
+              the expected ``tuple[float, float, float, bool]`` format.
         """
         vr = Vasprun(
             path_to_vasprun,
@@ -199,11 +208,9 @@ class DOS:
             dict: DOS as dictionary
 
         Note:
-            The defect dictionary will always report the DOS data is not spin
-            polarised, even if the input data was. This is an artefact related
-            to maintaining the ability of `py-sc-fermi` to read files formatted
-            for the FORTRAN SC-Fermi code. Future versions will consider how
-            the code parses these files such that this is no longer an issue.
+            ``spin_pol`` is always ``False``: a spin-polarised DOS is summed
+            into a single total at construction, so the stored density is
+            single-channel and reloads identically from this dictionary.
         """
 
         return dict(

--- a/tests/test_defect_system.py
+++ b/tests/test_defect_system.py
@@ -3,7 +3,7 @@ import math
 import os
 import unittest
 import warnings
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import numpy as np
 import yaml
@@ -3713,6 +3713,48 @@ class TestDiluteLimitWarning(unittest.TestCase):
             result = system.result
         self.assertIn("S", result.high_occupancy_species)
         self.assertGreater(result.high_occupancy_species["S"], 0.01)
+
+
+class TestConvergenceTolerance(unittest.TestCase):
+    """``convergence_tolerance`` sets the ``brentq`` precision of the
+    self-consistent Fermi-energy solve: it is forwarded as ``xtol``, and omitted
+    (leaving scipy's default) when ``None``. Pins the wiring so a regression that
+    dropped it (silently making the tolerance a no-op) is caught."""
+
+    def setUp(self):
+        self.dos = DOS(
+            dos=np.ones(101), edos=np.linspace(-5.0, 5.0, 101), bandgap=2.0, nelect=10
+        )
+        self.species = DefectSpecies(
+            "V",
+            nsites=10,
+            charge_states=[
+                DefectChargeState(charge=0, energy=1.0, degeneracy=1),
+                DefectChargeState(charge=1, energy=1.3, degeneracy=1),
+            ],
+        )
+
+    def _system(self, convergence_tolerance):
+        return DefectSystem(
+            defect_species=[self.species],
+            dos=self.dos,
+            volume=100,
+            temperature=300,
+            convergence_tolerance=convergence_tolerance,
+            occupancy_warning_threshold=None,
+        )
+
+    def test_convergence_tolerance_passed_to_brentq_as_xtol(self):
+        system = self._system(1e-3)
+        with patch("py_sc_fermi.defect_system.brentq", return_value=0.5) as mock_brentq:
+            system.get_sc_fermi()
+        self.assertEqual(mock_brentq.call_args.kwargs.get("xtol"), 1e-3)
+
+    def test_no_xtol_passed_when_convergence_tolerance_is_none(self):
+        system = self._system(None)
+        with patch("py_sc_fermi.defect_system.brentq", return_value=0.5) as mock_brentq:
+            system.get_sc_fermi()
+        self.assertNotIn("xtol", mock_brentq.call_args.kwargs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Clears the docs and hygiene tail from the recent full-codebase review.

- Corrects docstrings that no longer matched the code: `DOS.from_vasprun` (`nelect` is read from the vasprun's `NELECT` parameter when not supplied), `DOS.as_dict` (the `spin_pol` note cited the removed FORTRAN input path; the real reason is that spin channels are summed at construction), and the inverted sign in `DefectSystem.q_tot`'s description of the returned net charge. Also adds the missing `total_defect_charge_contributions` docstring, completes the `DefectChargeState` argument types, fills the empty `charge_states` summary, and fixes a US spelling and a mangled formula comment.
- Removes the unused `DefectSpecies.site_weights` method (no call sites).
- Adds tests that `convergence_tolerance` is forwarded to `brentq` as `xtol`, and omitted when `None`, so a regression that dropped the wiring cannot silently make the tolerance a no-op.
