### PR TITLE
v3 documentation: reframed landing page and a theory page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,19 +14,83 @@ py-sc-fermi
    FAQs
    py_sc_fermi
 
-:py:mod:`py-sc-fermi` is an open-source Python package for calculating the concentration of point defects in (semiconducting) crystalline materials.
-The required inputs are the volume, density of states of the bulk material, and the formation energies and degeneracies of the point defects. 
-The outputs include the self consistent Fermi energy, defect transition levels, and concentrations of the point defects, electrons and holes at a given temperature.
-:py:mod:`py-sc-fermi` uses a numerical method to solve for the self-consistent Fermi level in a material, necessary for accurately quantifing the populations of point defects in such materials. 
-
-The approach used in this code was initially based off the algorithm used by the FORTRAN code `SC-Fermi <https://github.com/jbuckeridge/sc-fermi>`_, as described in this `Paper <https://www.sciencedirect.com/science/article/pii/S0010465519302048>`_.
+:py:mod:`py-sc-fermi` is an open-source Python package for calculating
+equilibrium point-defect and carrier concentrations in crystalline
+semiconductors. From the cell volume, the bulk density of states, and the
+formation energies and degeneracies of a set of point defects, it solves
+self-consistently for the Fermi level that enforces charge neutrality, and
+returns the equilibrium defect, electron, and hole concentrations, together
+with the defect transition levels, at a given temperature.
 
 .. image:: figures/outline.png
    :width: 800px
    :height: 400px
    :align: center
-  
+
 |
+
+Quickstart
+==========
+
+.. code-block:: python
+
+    from py_sc_fermi.dos import DOS
+    from py_sc_fermi.defect_charge_state import DefectChargeState
+    from py_sc_fermi.defect_species import DefectSpecies
+    from py_sc_fermi.defect_system import DefectSystem
+
+    # bulk density of states (the electron count and band gap are read from the vasprun)
+    dos = DOS.from_vasprun("vasprun.xml")
+
+    defects = [
+        DefectSpecies(
+            "V_O",
+            nsites=2,
+            charge_states=[
+                DefectChargeState(charge=0, energy=4.7, degeneracy=1),
+                DefectChargeState(charge=2, energy=1.1, degeneracy=1),
+            ],
+        ),
+        # ... one DefectSpecies per defect
+    ]
+
+    system = DefectSystem(
+        defect_species=defects,
+        dos=dos,
+        volume=250.0,      # cubic Angstroms
+        temperature=1000,  # Kelvin
+    )
+
+    result = system.result
+    print(result)           # self-consistent Fermi level, carriers, and defect concentrations
+    result.fermi_energy     # Fermi level (eV, referenced to the VBM)
+    result.concentrations   # {defect name: concentration in cm^-3}
+
+The :doc:`tutorials` page works through this example and the features below in
+full.
+
+Features
+========
+
+- The self-consistent Fermi level and equilibrium defect, electron, and hole
+  concentrations at a fixed temperature.
+- Site-exclusion (Langmuir) statistics by default, capping each defect at its
+  available sites; the dilute Boltzmann limit is recovered automatically.
+- Temperature series and temperature-dependent band-edge shifts through
+  ``DefectSystemFactory``.
+- Frozen-defect and anneal-and-quench workflows through ``fixed_concentrations``.
+- Constraints on the defect populations: a shared budget of sites across
+  species (``site_pools``), and a fixed total content of an element solved
+  through its chemical potential (``element_pools``).
+- Metastable charge states, and Boltzmann-weighted effective formation energies.
+- Defect transition-level diagrams.
+
+Upgrading from v2? The :doc:`migrating_to_v3` guide covers the breaking changes
+and the new default statistics.
+
+py-sc-fermi's self-consistent Fermi-level algorithm was originally based on that
+of the FORTRAN code `SC-Fermi <https://github.com/jbuckeridge/sc-fermi>`_
+(`Buckeridge 2019 <https://www.sciencedirect.com/science/article/pii/S0010465519302048>`_).
 
 Papers that use :py:mod:`py-sc-fermi`
 ======================================
@@ -42,4 +106,3 @@ Searching
 =========
 
 :ref:`genindex` | :ref:`modindex` | :ref:`search`
-

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -64,11 +64,11 @@ Quickstart
 
     result = system.result
     print(result)           # self-consistent Fermi level, carriers, and defect concentrations
-    result.fermi_energy     # Fermi level (eV, referenced to the VBM)
+    result.fermi_energy     # Fermi level (eV, referenced to the valence-band maximum)
     result.concentrations   # {defect name: concentration in cm^-3}
 
-The :doc:`tutorials` page works through this example and the features below in
-full.
+The :doc:`tutorials` page walks through a complete example with these building
+blocks, and the features below, in full.
 
 Features
 ========

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,6 +9,7 @@ py-sc-fermi
 
    installation
    migrating_to_v3
+   theory
    usage_notes
    tutorials
    FAQs
@@ -85,8 +86,10 @@ Features
 - Metastable charge states, and Boltzmann-weighted effective formation energies.
 - Defect transition-level diagrams.
 
-Upgrading from v2? The :doc:`migrating_to_v3` guide covers the breaking changes
-and the new default statistics.
+The :doc:`theory` page sets out the model behind these features: the
+site-exclusion statistics, the charge-neutrality solve, and the pool
+constraints. Upgrading from v2? The :doc:`migrating_to_v3` guide covers the
+breaking changes and the new default statistics.
 
 py-sc-fermi's self-consistent Fermi-level algorithm was originally based on that
 of the FORTRAN code `SC-Fermi <https://github.com/jbuckeridge/sc-fermi>`_

--- a/docs/source/theory.rst
+++ b/docs/source/theory.rst
@@ -36,7 +36,7 @@ where ``g_i`` is the state's degeneracy and ``kT`` the thermal energy.
 Because the charge states of a species draw on the same finite set of sites,
 they compete for occupancy. Each site is either empty or in one of the
 competing states, so its occupation follows a single-site partition function
-``1 + sum_j w_j`` — the ``1`` for the empty site, one ``w_j`` for each state
+``1 + sum_j w_j``: the ``1`` for the empty site, one ``w_j`` for each state
 that can occupy it. The concentration of state ``i`` is then::
 
     c_i = N_free * w_i / (1 + sum_j w_j)
@@ -59,11 +59,10 @@ This is the defect concentration of the standard dilute model (`Zhang and
 Northrup, 1991 <https://doi.org/10.1103/PhysRevLett.67.2339>`_), and the
 statistics used by py-sc-fermi v2 and the original SC-Fermi code. Site
 exclusion and the dilute limit therefore agree wherever defects are dilute, and
-part ways only as a species approaches its site budget — at low formation
-energies, high temperatures, or otherwise high occupancy — where site exclusion
+part ways only as a species approaches its site budget (at low formation
+energies, high temperatures, or otherwise high occupancy), where site exclusion
 holds the concentration below the unbounded dilute value. The difference grows
-smoothly with occupancy; there is no occupancy below which the two are exactly
-equal.
+smoothly with occupancy, vanishing only in the dilute limit.
 
 
 When site exclusion is not enough
@@ -92,10 +91,9 @@ Shared site pools
 
 By default each species has its own budget of ``nsites`` sites, and only its
 own charge states compete for them. When several species genuinely share one
-set of physical sites — substitutional species that can each sit on the same
-sublattice, say — group them in a ``site_pools`` entry. Site exclusion is then
-applied across the group: the members draw on one shared ``N_free`` and
-together occupy at most all of it.
+set of physical sites, as substitutional species sharing a sublattice do, group
+them in a ``site_pools`` entry. Site exclusion is then applied across the group:
+the members draw on one shared ``N_free`` and together occupy at most all of it.
 
 
 The self-consistent Fermi level
@@ -155,23 +153,23 @@ constraint is::
 
     sum_i stoichiometry_i * c_i = target
 
-py-sc-fermi enforces it by introducing a chemical potential ``mu`` for the
-element and folding it into each member's weight, ``w_i -> w_i * exp(s_i *
-mu)``, then solving for the ``mu`` at which the content meets the target. This
-is mass action: raising ``mu`` makes the element's interstitials cheaper and
-its vacancies more costly, feeding atoms into the cell; lowering it does the
-reverse. A target of zero with mixed-sign stoichiometry pins exact
-stoichiometry, with interstitials balancing vacancies; a negative target sets an
-off-stoichiometric deficiency; and a scan can cross zero continuously.
+py-sc-fermi enforces it by shifting the element's chemical potential by
+``delta_mu`` and folding that into each member's weight,
+``w_i -> w_i * exp(s_i * delta_mu / kT)``, then solving for the ``delta_mu`` at
+which the content meets the target. This is mass action: raising ``delta_mu``
+makes the element's interstitials cheaper and its vacancies more costly, feeding
+atoms into the cell; lowering it does the reverse. A target of zero with
+mixed-sign stoichiometry pins exact stoichiometry, with interstitials balancing
+vacancies; a negative target sets an off-stoichiometric deficiency; and a scan
+can cross zero continuously.
 
 
 What the model can and cannot judge
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-py-sc-fermi solves for the chemical potential and reports it, through
-``element_chemical_potential_shifts``, as a shift ``delta_mu`` relative to the
-reference at which the formation energies were defined: a target above the
-element's unconstrained content gives ``delta_mu > 0``, one below it
+``element_chemical_potential_shifts`` returns the solved ``delta_mu``, measured
+relative to the reference at which the formation energies were defined: a target
+above the element's unconstrained content gives ``delta_mu > 0``, one below it
 ``delta_mu < 0``.
 
 Two limits bound the target, and only one of them is the model's to enforce.
@@ -188,8 +186,8 @@ that the equilibrium solve will still report if asked.
 Metastable states and transition levels
 ----------------------------------------
 
-A single formal charge can correspond to more than one atomic configuration —
-two geometries of a 2+ oxygen vacancy, say. py-sc-fermi represents these
+A single formal charge can correspond to more than one atomic configuration,
+such as two geometries of a 2+ oxygen vacancy. py-sc-fermi represents these
 metastable states as separate ``DefectChargeState`` objects that share a formal
 charge and are given distinct names.
 
@@ -238,18 +236,18 @@ read-only. A snapshot therefore has a single well-defined solved state, computed
 on first access to ``result`` and cached.
 
 A temperature series is a series of such snapshots. ``DefectSystemFactory``
-holds the temperature-dependent inputs — band-edge shifts and formation-energy
-corrections as functions of temperature — and ``at(T)`` evaluates them and
+holds the temperature-dependent inputs (band-edge shifts and formation-energy
+corrections as functions of temperature), and ``at(T)`` evaluates them and
 builds a fresh, independent ``DefectSystem`` for each temperature. The snapshots
 share no state, so a sweep is a straightforward series of independent solves.
 
 Band-edge shifts enter a snapshot through the density of states. ``vbm_shift``
 and ``cbm_shift`` scissor the DOS, changing the band gap by
 ``cbm_shift - vbm_shift`` and so moving the carrier concentrations and the Fermi
-level; optionally they also shift the defect formation energies, for the case
-where the defect levels are taken to stay fixed in absolute energy as the bands
-move rather than riding rigidly with them. Supplied as functions on the factory,
-the shifts are re-evaluated at every temperature in a sweep.
+level. Optionally, ``vbm_shift`` also shifts the defect formation energies, for
+the case where the defect levels are taken to stay fixed in absolute energy as
+the bands move rather than riding rigidly with them. Supplied as functions on
+the factory, the shifts are re-evaluated at every temperature in a sweep.
 
 Anneal and quench uses the snapshot model directly. Defect populations are often
 set at a high growth or annealing temperature and then frozen in as the material

--- a/docs/source/theory.rst
+++ b/docs/source/theory.rst
@@ -1,0 +1,261 @@
+The defect-equilibrium model
+============================
+
+py-sc-fermi computes the equilibrium concentrations of point defects and free
+carriers in a semiconductor at a fixed temperature. Given the formation
+energies of a set of defect charge states and the host density of states, it
+finds the Fermi level at which the crystal is charge-neutral, and reports the
+defect, electron, and hole concentrations there.
+
+This page sets out the model behind that calculation: how a defect's
+concentration follows from its formation energy, how charge neutrality fixes
+the Fermi level, how site and element budgets enter as constraints, and how
+metastable states and temperature-dependent inputs are handled. Throughout, the
+formation energies and the density of states are taken as given; computing them
+is outside py-sc-fermi's scope.
+
+
+Defect concentrations and site exclusion
+----------------------------------------
+
+A point defect forms on one of a finite set of equivalent sites in the unit
+cell. A species declares how many such sites the cell provides through
+``nsites``, and each of its charge states carries a formation energy that
+varies linearly with the Fermi level::
+
+    E_i(E_F) = E_i(0) + q_i * E_F
+
+with ``q_i`` the charge and ``E_i(0)`` the formation energy at the
+valence-band maximum (``E_F = 0``). The tendency of a site to adopt charge
+state ``i`` is set by its Boltzmann weight::
+
+    w_i = g_i * exp(-E_i(E_F) / kT)
+
+where ``g_i`` is the state's degeneracy and ``kT`` the thermal energy.
+
+Because the charge states of a species draw on the same finite set of sites,
+they compete for occupancy. Each site is either empty or in one of the
+competing states, so its occupation follows a single-site partition function
+``1 + sum_j w_j`` — the ``1`` for the empty site, one ``w_j`` for each state
+that can occupy it. The concentration of state ``i`` is then::
+
+    c_i = N_free * w_i / (1 + sum_j w_j)
+
+with ``N_free`` the number of available sites. This is the lattice-gas
+(Langmuir) result, and it is py-sc-fermi's default. It caps the occupancy of
+the site set at ``N_free``: no defect can exceed the sites that host it.
+
+
+The dilute limit
+~~~~~~~~~~~~~~~~~
+
+When the sites are mostly empty the total weight ``sum_j w_j`` is much smaller
+than one, the denominator approaches ``1``, and the concentration reduces to
+the familiar dilute expression::
+
+    c_i = N_free * w_i = N_free * g_i * exp(-E_i(E_F) / kT)
+
+This is the defect concentration of the standard dilute model (`Zhang and
+Northrup, 1991 <https://doi.org/10.1103/PhysRevLett.67.2339>`_), and the
+statistics used by py-sc-fermi v2 and the original SC-Fermi code. Site
+exclusion and the dilute limit therefore agree wherever defects are dilute, and
+part ways only as a species approaches its site budget — at low formation
+energies, high temperatures, or otherwise high occupancy — where site exclusion
+holds the concentration below the unbounded dilute value. The difference grows
+smoothly with occupancy; there is no occupancy below which the two are exactly
+equal.
+
+
+When site exclusion is not enough
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Site exclusion corrects the *counting* of configurations: it stops a defect
+from occupying more sites than exist. It leaves the *energetics* untouched —
+every formation energy is still that of an isolated defect, independent of how
+many others are present. Once a defect occupies an appreciable fraction of its
+sites, that independence is the assumption that fails: neighbouring defects
+begin to perturb one another's formation energies, and concentrations computed
+from isolated-defect energies become unreliable.
+
+py-sc-fermi cannot model those interactions, but it can flag when they are
+likely to matter. When a solve leaves a species above
+``occupancy_warning_threshold`` (one per cent of its sites by default), it
+raises a ``DiluteLimitWarning`` naming the species and its occupancy. The same
+verdict is available without the warning as ``result.high_occupancy_species``,
+and the solved occupancy of every species as ``system.site_percentages()``. The
+threshold is a prompt to check the model against your system, not a boundary
+between valid and invalid results.
+
+
+Shared site pools
+~~~~~~~~~~~~~~~~~~
+
+By default each species has its own budget of ``nsites`` sites, and only its
+own charge states compete for them. When several species genuinely share one
+set of physical sites — substitutional species that can each sit on the same
+sublattice, say — group them in a ``site_pools`` entry. Site exclusion is then
+applied across the group: the members draw on one shared ``N_free`` and
+together occupy at most all of it.
+
+
+The self-consistent Fermi level
+-------------------------------
+
+The Fermi level is not an input to the calculation: it is the one unknown that
+py-sc-fermi solves for. Every defect concentration depends on it through the
+formation energies ``E_i(E_F)``, the free-carrier concentrations depend on it
+too, and the value that makes the crystal charge-neutral is what fixes them
+all.
+
+The free carriers come from the density of states. Integrating the electronic
+DOS against the Fermi-Dirac distribution gives the hole concentration ``p0`` in
+the valence band and the electron concentration ``n0`` in the conduction band,
+each a function of the Fermi level and temperature. The valence-band maximum
+sits at ``E_F = 0`` and the conduction-band minimum at the band gap, so raising
+the Fermi level fills electrons and depletes holes.
+
+Charge neutrality balances every positive charge against every negative one::
+
+    p0 + sum(positive defect charge) = n0 + sum(negative defect charge)
+
+the left side collecting the holes and the positively-charged defects, the
+right the electrons and the negatively-charged defects, each defect weighted by
+its concentration and the magnitude of its charge. Written as a single
+residual::
+
+    q_tot(E_F) = [n0 + negative] - [p0 + positive]
+
+this is zero exactly at the self-consistent Fermi level. As the Fermi level
+sweeps the DOS energy window the balance tips from hole-rich at the low-energy
+end to electron-rich at the high-energy end, so ``q_tot`` changes sign once
+between them. py-sc-fermi brackets the window and locates that crossing with
+Brent's method. ``convergence_tolerance`` sets the tolerance on the returned
+Fermi level; ``DefectSystem.result`` reports it as ``fermi_energy``, referenced
+to the valence-band maximum, alongside ``p0``, ``n0``, and the defect
+concentrations evaluated there.
+
+
+Element constraints as chemical potentials
+------------------------------------------
+
+By default a charge state's formation energy already fixes everything its
+concentration needs: ``E_i(0)`` was defined at some chosen set of atomic
+chemical potentials, and the concentration follows directly. This is an
+open-system picture — each element is drawn from an implicit reservoir held at a
+fixed chemical potential.
+
+Sometimes the constraint runs the other way: not the chemical potential of an
+element, but its total amount. You might hold the total oxygen content of the
+cell fixed, or pin an exact stoichiometry, and ask what chemical potential that
+implies. An ``element_pools`` entry expresses this. It names an element, a
+target content per cell, and the member species that carry the element, each
+with a signed stoichiometry — positive where the species adds atoms of the
+element (an interstitial), negative where it removes them (a vacancy). The
+constraint is::
+
+    sum_i stoichiometry_i * c_i = target
+
+py-sc-fermi enforces it by introducing a chemical potential ``mu`` for the
+element and folding it into each member's weight, ``w_i -> w_i * exp(s_i *
+mu)``, then solving for the ``mu`` at which the content meets the target. This
+is mass action: raising ``mu`` makes the element's interstitials cheaper and
+its vacancies more costly, feeding atoms into the cell; lowering it does the
+reverse. A target of zero with mixed-sign stoichiometry pins exact
+stoichiometry, with interstitials balancing vacancies; a negative target sets an
+off-stoichiometric deficiency; and a scan can cross zero continuously.
+
+
+What the model can and cannot judge
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+py-sc-fermi solves for the chemical potential and reports it, through
+``element_chemical_potential_shifts``, as a shift ``delta_mu`` relative to the
+reference at which the formation energies were defined: a target above the
+element's unconstrained content gives ``delta_mu > 0``, one below it
+``delta_mu < 0``.
+
+Two limits bound the target, and only one of them is the model's to enforce.
+Site exclusion is: a target needing more atoms than there are sites to host
+them is unreachable, and py-sc-fermi rejects it. Thermodynamic accessibility is
+not: whether the element's chemical potential can actually reach ``delta_mu``
+without precipitating a competing phase depends on the phase diagram, which
+py-sc-fermi does not have. The reported shift is meant to be checked against an
+external stability region — a shift inside it corresponds to an accessible
+concentration, one outside it to a supersaturated or otherwise unphysical state
+that the equilibrium solve will still report if asked.
+
+
+Metastable states and transition levels
+----------------------------------------
+
+A single formal charge can correspond to more than one atomic configuration —
+two geometries of a 2+ oxygen vacancy, say. py-sc-fermi represents these
+metastable states as separate ``DefectChargeState`` objects that share a formal
+charge and are given distinct names.
+
+In the concentration solve, no special treatment is needed: each metastable
+state is an independent competitor in its site-exclusion group, with its own
+weight ``w_i``, so its population emerges from the same Langmuir expression as
+any other state. The Boltzmann weighting between configurations is not a
+separate step; it falls out of the competition.
+
+The combination becomes explicit only when a *single* formation energy is
+wanted for a formal charge — to draw a transition-level diagram, or to report
+an effective formation energy. There the states sharing a charge are collapsed
+into one value::
+
+    F(E_F) = -kT * ln( sum_i g_i * exp(-E_i(E_F) / kT) )
+
+The ``temperature`` argument of ``effective_formation_energy``,
+``get_formation_energies``, ``tl_profile`` and
+``get_transition_level_and_energy`` controls this collapse. At
+``temperature = 0`` (the default) it reduces to the lowest-energy state at each
+Fermi level — the usual lower-envelope formation-energy curve. Above zero it is
+the smooth Boltzmann-weighted combination, in which a low-lying metastable state
+contributes before it becomes the ground state. This argument sets only how
+metastable states are combined for reporting; it is independent of the
+temperature at which the system is solved.
+
+A transition level is the Fermi energy at which two charges are equal in
+formation energy — where the lower envelope switches from one charge to the
+next. Between charges ``q1`` and ``q2`` it lies at::
+
+    E_F = (E_q2 - E_q1) / (q1 - q2)
+
+with the formation energies evaluated at the band edge.
+``get_transition_levels`` returns these profiles for every species over the DOS
+energy range.
+
+
+The fixed-temperature snapshot model
+------------------------------------
+
+A ``DefectSystem`` is a snapshot at one temperature. Everything that defines the
+equilibrium — the temperature, the density of states, any band-edge shifts,
+formation-energy corrections, and fixed concentrations — is supplied at
+construction and cannot be changed afterwards; the public attributes are
+read-only. A snapshot therefore has a single well-defined solved state, computed
+on first access to ``result`` and cached.
+
+A temperature series is a series of such snapshots. ``DefectSystemFactory``
+holds the temperature-dependent inputs — band-edge shifts and formation-energy
+corrections as functions of temperature — and ``at(T)`` evaluates them and
+builds a fresh, independent ``DefectSystem`` for each temperature. The snapshots
+share no state, so a sweep is a straightforward series of independent solves.
+
+Band-edge shifts enter a snapshot through the density of states. ``vbm_shift``
+and ``cbm_shift`` scissor the DOS, changing the band gap by
+``cbm_shift - vbm_shift`` and so moving the carrier concentrations and the Fermi
+level; optionally they also shift the defect formation energies, for the case
+where the defect levels are taken to stay fixed in absolute energy as the bands
+move rather than riding rigidly with them. Supplied as functions on the factory,
+the shifts are re-evaluated at every temperature in a sweep.
+
+Anneal and quench uses the snapshot model directly. Defect populations are often
+set at a high growth or annealing temperature and then frozen in as the material
+cools faster than the defects can re-equilibrate. To model this, solve one
+snapshot at the annealing temperature, take the total concentrations it
+predicts, and solve a second snapshot at the lower temperature with those totals
+held fixed through ``fixed_concentrations``; each frozen total is held while its
+species' charge states re-equilibrate to the low-temperature Fermi level. The
+migration guide and the tutorial give the worked idiom.

--- a/docs/source/usage_notes.rst
+++ b/docs/source/usage_notes.rst
@@ -1,8 +1,8 @@
 Usage notes
 ===========
 
-Conventions and units. For the model behind the calculation — the statistics,
-the charge-neutrality solve, and the pool constraints — see :doc:`theory`.
+Conventions and units. For the model behind the calculation (the statistics,
+the charge-neutrality solve, and the pool constraints), see :doc:`theory`.
 
 - "Unit cell" throughout means the cell for which the density-of-states data
   was calculated. Volumes, degeneracies, and electron counts must all be
@@ -14,9 +14,9 @@ the charge-neutrality solve, and the pool constraints — see :doc:`theory`.
 
   - energy: electron volts
   - temperature: Kelvin
-  - volume: Angstroms :superscript:`3`
+  - volume: Angstroms\ :superscript:`3`
 
-- Concentrations are reported in cm :superscript:`-3`. Internally py-sc-fermi
+- Concentrations are reported in cm\ :superscript:`-3`. Internally py-sc-fermi
   works in per-unit-cell counts, and every concentration on
   ``DefectSystem.result`` has a ``_per_cell`` counterpart. Each function's
   documentation states which it expects or returns; if one does not, that is a

--- a/docs/source/usage_notes.rst
+++ b/docs/source/usage_notes.rst
@@ -1,38 +1,23 @@
 Usage notes
--------------------------------------
-- At different points in the documentation, a "unit cell" is referred to, this is the cell for which the density
-  of states data was calculated, and any volumes, degeneracies and numbers of electrons provided should be 
-  consitent with this structure for the reported defect concentrations to be accurate. In most cases, inconsistent
-  specification of these values will lead to incorrect Fermi energies.
-- The reported Fermi energy and transition levels reported are referenced to 0 eV; the code expects that the input
-  density of states data is zeroed on the valence band maximum.
-- The code operates using the following units,
-  and all user-input must be consistent:
-  
-  - energy: electron volts. 
-  
-  - temperature: Kelvin.  
-  
-  - volume: Angstroms :superscript:`3`. 
-  
-- Concentrations are a special case, internally, the :py:mod:`py-sc-fermi` operates in the concentration of sites in the unit cell 
-  which are defective, but will report in cm :superscript:`-3`. The documentation should always specify what kind of concentration
-  is expected by a particular function, if it does not, this is a bug! Please report it. 
- 
-- :py:mod:`py-sc-fermi` calculates defect concentrations from the formation energies it is given, following
-  the model of `Zhang and Northrup`_https://doi.org/10.1103/PhysRevLett.67.2339. Two independent mechanisms are
-  available for bringing temperature-dependence into those formation energies:
+===========
 
-  - :py:class:`~py_sc_fermi.defect_system.DefectSystem` accepts ``vbm_shift``, ``cbm_shift``,
-    ``formation_energy_corrections`` and ``rigid_shift`` arguments, for applying temperature-dependent
-    band-edge or per-charge-state formation-energy corrections (e.g. from a phonon-renormalisation
-    calculation) at a given temperature. :py:class:`~py_sc_fermi.defect_system.DefectSystemFactory` builds a
-    series of such ``DefectSystem`` snapshots from temperature-dependent correction functions, for running
-    a temperature sweep. See the tutorial for worked examples.
+Conventions and units. For the model behind the calculation — the statistics,
+the charge-neutrality solve, and the pool constraints — see :doc:`theory`.
 
-  - :py:meth:`~py_sc_fermi.defect_species.DefectSpecies.effective_formation_energy`,
-    :py:meth:`~py_sc_fermi.defect_species.DefectSpecies.get_formation_energies`,
-    :py:meth:`~py_sc_fermi.defect_species.DefectSpecies.tl_profile` and
-    :py:meth:`~py_sc_fermi.defect_species.DefectSpecies.get_transition_level_and_energy` all accept an optional
-    ``temperature`` argument, which Boltzmann-averages over any metastable
-    :py:class:`~py_sc_fermi.defect_charge_state.DefectChargeState`\\ s that share a formal charge.
+- "Unit cell" throughout means the cell for which the density-of-states data
+  was calculated. Volumes, degeneracies, and electron counts must all be
+  consistent with that same cell, or the reported Fermi energy and
+  concentrations will be wrong.
+- The reported Fermi energy and transition levels are referenced to 0 eV at the
+  valence-band maximum; the input density of states must be zeroed there.
+- All user input must use these units:
+
+  - energy: electron volts
+  - temperature: Kelvin
+  - volume: Angstroms :superscript:`3`
+
+- Concentrations are reported in cm :superscript:`-3`. Internally py-sc-fermi
+  works in per-unit-cell counts, and every concentration on
+  ``DefectSystem.result`` has a ``_per_cell`` counterpart. Each function's
+  documentation states which it expects or returns; if one does not, that is a
+  bug. Please report it.


### PR DESCRIPTION
Part of the v3 documentation overhaul (#65).

- Reframe the landing page around what the package does, with a runnable quickstart and a features list, in place of the FORTRAN-port framing.
- Add a theory page describing the defect-equilibrium model: site-exclusion (Langmuir) statistics and the dilute limit, the charge-neutrality solve for the Fermi level, element constraints as chemical potentials, metastable states and transition levels, and the fixed-temperature snapshot model.
- Refocus the usage notes as a units and conventions reference, with the statistical model and temperature-dependence mechanisms moved to the theory page.