### PR TITLE
Fix invalid RST inline-literal plurals in DefectSpecies docstrings

### DIFF
--- a/py_sc_fermi/defect_species.py
+++ b/py_sc_fermi/defect_species.py
@@ -341,7 +341,7 @@ class DefectSpecies:
             temperature (float, optional): if 0 (the default), the formation
                 energy of a charge is that of its lowest-energy
                 ``DefectChargeState``. If > 0, charges with multiple
-                ``DefectChargeState``s (metastable forms) instead use the
+                ``DefectChargeState`` objects (metastable forms) instead use the
                 Boltzmann-weighted effective formation energy of those forms.
                 Defaults to 0.
 
@@ -371,7 +371,7 @@ class DefectSpecies:
             efermi_min (float): minimum Fermi energy
             efermi_max (float): maximum Fermi energy
             temperature (float, optional): temperature used to combine
-                metastable ``DefectChargeState``s sharing a formal charge, via
+                metastable ``DefectChargeState`` objects sharing a formal charge, via
                 ``get_formation_energies``/``get_transition_level_and_energy``.
                 Defaults to 0, in which case each charge is represented by its
                 lowest-energy state.
@@ -426,7 +426,7 @@ class DefectSpecies:
             q1 (int): charge on first ``DefectChargeState`` of interest
             q2 (int): charge on second ``DefectChargeState`` of interest
             temperature (float, optional): temperature used to combine
-                metastable ``DefectChargeState``s sharing a formal charge, via
+                metastable ``DefectChargeState`` objects sharing a formal charge, via
                 ``get_formation_energies``. Defaults to 0.
 
         Returns:


### PR DESCRIPTION
Three `DefectSpecies` docstrings pluralised an inline literal by writing
``DefectChargeState``s, with a letter directly after the closing
double-backtick. That is not a valid inline-literal end-string.

- `get_formation_energies` raised a Sphinx "Inline literal start-string
  without end-string" warning that dirtied the docs build.
- `tl_profile` and `get_transition_level_and_energy` raised no warning but
  rendered a garbled run-on literal, because docutils mis-paired the
  double-backticks on the following line.

All three are reworded to ``DefectChargeState`` objects, the phrasing
already used throughout the file. A Sphinx HTML build of `docs/source` no
longer emits the warning and renders each literal correctly.

Kept as a separate PR from the docs-only reframe in #94 because it touches
a source file rather than the changed docs pages.
